### PR TITLE
Use Llama 4 Scout for image descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ Required environment variables are documented in README.md. Critical ones:
 **Audio/Image Transcription (/transcribe):**
 - Must be used as reply to messages containing audio, images, or stickers
 - Audio transcription via Cloudflare Workers AI
-- Image description via LLaVA model
+- Image description via Llama 4 Scout model
 - 7-day Redis caching for both audio and image processing
 - Automatic file download from Telegram servers
 


### PR DESCRIPTION
## Summary
- switch Cloudflare image processing to `@cf/meta/llama-4-scout-17b-16e-instruct`
- update documentation and logs to reference the new model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e8775f8a8832e887fc12b808b3fea