### PR TITLE
Document /links command and separate link attribution

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1092,6 +1092,8 @@ comandos disponibles boludo:
 
 - /instance: te digo donde estoy corriendo
 
+- /links reply|delete|off: te arreglo los links de twitter/x/bsky
+
 - /prices, /precio, /precios, /presio, /presios: top 10 cryptos en usd
 - /prices in btc: top 10 en btc
 - /prices 20: top 20 en usd
@@ -2696,7 +2698,7 @@ def handle_msg(message: Dict) -> str:
             if changed:
                 username = message.get("from", {}).get("username")
                 if username:
-                    fixed_text += f"\nShared by @{username}"
+                    fixed_text += f"\n\nShared by @{username}"
                 if link_mode == "delete":
                     delete_msg(chat_id, message_id)
                     send_msg(chat_id, fixed_text)

--- a/test.py
+++ b/test.py
@@ -1843,6 +1843,7 @@ def test_get_help_basic():
     assert "/dolar" in result
     assert "/usd" in result
     assert "/prices" in result
+    assert "/links" in result
 
 
 def test_get_instance_name_basic():
@@ -3775,7 +3776,8 @@ def test_handle_msg_link_reply():
         result = handle_msg(message)
 
         assert result == "ok"
-        mock_send.assert_called_once()
+        expected = "check https://fxtwitter.com/foo\n\nShared by @john"
+        mock_send.assert_called_once_with("123", expected, "1")
         mock_delete.assert_not_called()
         mock_save.assert_not_called()
 
@@ -3800,6 +3802,7 @@ def test_handle_msg_link_delete():
         result = handle_msg(message)
 
         assert result == "ok"
-        mock_delete.assert_called_once()
-        mock_send.assert_called_once()
+        expected = "look https://fixupx.com/bar\n\nShared by @ana"
+        mock_delete.assert_called_once_with("456", "2")
+        mock_send.assert_called_once_with("456", expected)
         mock_save.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `/links` instructions to help message
- Insert blank line before link attribution
- Test help and link fixer formatting

## Testing
- `pytest -q test.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7d0ab4cb8832e8bcb2750ba2282bd