### PR TITLE
Preserve links config

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -2626,7 +2626,7 @@ def configure_links(chat_id: str, params: str) -> str:
     if mode in {"reply", "delete"}:
         redis_client.set(key, mode)
         return f"Link fixer set to {mode} mode"
-    if mode == "off" or mode == "":
+    if mode == "off":
         redis_client.delete(key)
         return "Link fixer disabled"
 

--- a/test.py
+++ b/test.py
@@ -3756,6 +3756,18 @@ def test_configure_links_sets_and_disables():
         assert "disabled" in resp
 
 
+def test_configure_links_usage_shows_current():
+    with patch("api.index.config_redis") as mock_redis:
+        redis_client = MagicMock()
+        redis_client.get.return_value = "reply"
+        mock_redis.return_value = redis_client
+
+        resp = configure_links("123", "")
+        redis_client.delete.assert_not_called()
+        assert "Usage:" in resp
+        assert "current: reply" in resp
+
+
 def test_handle_msg_link_reply():
     message = {
         "message_id": 1,


### PR DESCRIPTION
## Summary
- Avoid clearing /links settings when invoked without parameters
- Add regression test for /links config persistence

## Testing
- `pytest -q` *(no tests discovered)*
- `pytest -q test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7d37ec900832e92114f9ea39771d7