### PR TITLE
Expand link fixer to Reddit and TikTok

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1092,7 +1092,7 @@ comandos disponibles boludo:
 
 - /instance: te digo donde estoy corriendo
 
-- /links reply|delete|off: te arreglo los links de twitter/x/bsky/instagram
+- /links reply|delete|off: te arreglo los links de twitter/x/bsky/instagram/reddit/tiktok
 
 - /prices, /precio, /precios, /presio, /presios: top 10 cryptos en usd
 - /prices in btc: top 10 en btc
@@ -2608,6 +2608,8 @@ def replace_links(text: str) -> Tuple[str, bool]:
         r"(https?://)(?:www\.)?x\.com": r"\1fixupx.com",
         r"(https?://)(?:www\.)?bsky\.app": r"\1fxbsky.app",
         r"(https?://)(?:www\.)?instagram\.com": r"\1ddinstagram.com",
+        r"(https?://)(?:www\.)?reddit\.com": r"\1rxddit.com",
+        r"(https?://)(?:www\.)?tiktok\.com": r"\1vxtiktok.com",
     }
     new_text = text
     changed = False

--- a/test.py
+++ b/test.py
@@ -3733,7 +3733,7 @@ def test_complete_with_providers_all_fail():
 
 def test_replace_links():
     text = (
-        "Check https://twitter.com/foo and http://x.com/bar and https://bsky.app/baz and https://www.instagram.com/qux"
+        "Check https://twitter.com/foo and http://x.com/bar and https://bsky.app/baz and https://www.instagram.com/qux and https://www.reddit.com/r/foo and https://www.tiktok.com/@bar"
     )
     fixed, changed = replace_links(text)
     assert changed
@@ -3741,6 +3741,8 @@ def test_replace_links():
     assert "http://fixupx.com/bar" in fixed
     assert "https://fxbsky.app/baz" in fixed
     assert "https://ddinstagram.com/qux" in fixed
+    assert "https://rxddit.com/r/foo" in fixed
+    assert "https://vxtiktok.com/@bar" in fixed
 
 
 def test_configure_links_sets_and_disables():


### PR DESCRIPTION
## Summary
- extend link fixer to rewrite Reddit URLs to rxddit and TikTok URLs to vxtiktok
- document new behavior in /links help text
- test replacements for Reddit and TikTok links

## Testing
- `pytest -q test.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7d8ec55e0832e90c4a20bc488064d