### PR TITLE
Handle TikTok subdomains in link fixer

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -2609,7 +2609,7 @@ def replace_links(text: str) -> Tuple[str, bool]:
         r"(https?://)(?:www\.)?bsky\.app": r"\1fxbsky.app",
         r"(https?://)(?:www\.)?instagram\.com": r"\1ddinstagram.com",
         r"(https?://)(?:www\.)?reddit\.com": r"\1rxddit.com",
-        r"(https?://)(?:www\.)?tiktok\.com": r"\1vxtiktok.com",
+        r"(https?://)(?:[a-zA-Z0-9-]+\.)?tiktok\.com": r"\1vxtiktok.com",
     }
     new_text = text
     changed = False

--- a/test.py
+++ b/test.py
@@ -3733,7 +3733,9 @@ def test_complete_with_providers_all_fail():
 
 def test_replace_links():
     text = (
-        "Check https://twitter.com/foo and http://x.com/bar and https://bsky.app/baz and https://www.instagram.com/qux and https://www.reddit.com/r/foo and https://www.tiktok.com/@bar"
+        "Check https://twitter.com/foo and http://x.com/bar and https://bsky.app/baz and "
+        "https://www.instagram.com/qux and https://www.reddit.com/r/foo and "
+        "https://www.tiktok.com/@bar and https://vm.tiktok.com/ZMHGacxknMW5J-gEiNC/"
     )
     fixed, changed = replace_links(text)
     assert changed
@@ -3743,6 +3745,7 @@ def test_replace_links():
     assert "https://ddinstagram.com/qux" in fixed
     assert "https://rxddit.com/r/foo" in fixed
     assert "https://vxtiktok.com/@bar" in fixed
+    assert "https://vxtiktok.com/ZMHGacxknMW5J-gEiNC/" in fixed
 
 
 def test_configure_links_sets_and_disables():


### PR DESCRIPTION
## Summary
- extend `/links` fixer to handle TikTok links with any subdomain
- cover TikTok subdomain replacement in tests

## Testing
- `pytest -q` *(no tests found)*
- `pytest -q test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7da95d370832eb2c004742254b38f