### PR TITLE
Fix old.reddit links in /links command

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -2608,7 +2608,7 @@ def replace_links(text: str) -> Tuple[str, bool]:
         r"(https?://)(?:www\.)?x\.com": r"\1fixupx.com",
         r"(https?://)(?:www\.)?bsky\.app": r"\1fxbsky.app",
         r"(https?://)(?:www\.)?instagram\.com": r"\1ddinstagram.com",
-        r"(https?://)(?:www\.)?reddit\.com": r"\1rxddit.com",
+        r"(https?://)(?:www\.|old\.)?reddit\.com": r"\1rxddit.com",
         r"(https?://)(?:[a-zA-Z0-9-]+\.)?tiktok\.com": r"\1vxtiktok.com",
     }
     new_text = text

--- a/test.py
+++ b/test.py
@@ -3734,7 +3734,7 @@ def test_complete_with_providers_all_fail():
 def test_replace_links():
     text = (
         "Check https://twitter.com/foo and http://x.com/bar and https://bsky.app/baz and "
-        "https://www.instagram.com/qux and https://www.reddit.com/r/foo and "
+        "https://www.instagram.com/qux and https://www.reddit.com/r/foo and https://old.reddit.com/r/bar and "
         "https://www.tiktok.com/@bar and https://vm.tiktok.com/ZMHGacxknMW5J-gEiNC/"
     )
     fixed, changed = replace_links(text)
@@ -3744,6 +3744,7 @@ def test_replace_links():
     assert "https://fxbsky.app/baz" in fixed
     assert "https://ddinstagram.com/qux" in fixed
     assert "https://rxddit.com/r/foo" in fixed
+    assert "https://rxddit.com/r/bar" in fixed
     assert "https://vxtiktok.com/@bar" in fixed
     assert "https://vxtiktok.com/ZMHGacxknMW5J-gEiNC/" in fixed
 


### PR DESCRIPTION
## Summary
- fix /links replacement for old.reddit.com URLs
- test old.reddit.com handling in replace_links

## Testing
- `pytest -q test.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7dbe7f3f0832ea832b83b647f5783