### PR TITLE
Check embeds with full social URLs

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -2668,17 +2668,17 @@ def replace_links(text: str) -> Tuple[str, bool]:
     """Replace social links with alternative frontends"""
 
     patterns = [
-        (r"(https?://)(?:www\.)?twitter\.com", r"\1fxtwitter.com"),
-        (r"(https?://)(?:www\.)?x\.com", r"\1fixupx.com"),
-        (r"(https?://)(?:www\.)?bsky\.app", r"\1fxbsky.app"),
-        (r"(https?://)(?:www\.)?instagram\.com", r"\1ddinstagram.com"),
+        (r"(https?://)(?:www\.)?twitter\.com([^\s]*)", r"\1fxtwitter.com\2"),
+        (r"(https?://)(?:www\.)?x\.com([^\s]*)", r"\1fixupx.com\2"),
+        (r"(https?://)(?:www\.)?bsky\.app([^\s]*)", r"\1fxbsky.app\2"),
+        (r"(https?://)(?:www\.)?instagram\.com([^\s]*)", r"\1ddinstagram.com\2"),
         (
-            r"(https?://)((?:[a-zA-Z0-9-]+\.)?)reddit\.com",
-            r"\1\2rxddit.com",
+            r"(https?://)((?:[a-zA-Z0-9-]+\.)?)reddit\.com([^\s]*)",
+            r"\1\2rxddit.com\3",
         ),
         (
-            r"(https?://)((?:[a-zA-Z0-9-]+\.)?)tiktok\.com",
-            r"\1\2vxtiktok.com",
+            r"(https?://)((?:[a-zA-Z0-9-]+\.)?)tiktok\.com([^\s]*)",
+            r"\1\2vxtiktok.com\3",
         ),
     ]
 
@@ -2688,11 +2688,12 @@ def replace_links(text: str) -> Tuple[str, bool]:
         def _sub(match: re.Match) -> str:
             original = match.group(0)
             replaced = match.expand(repl)
-            if url_is_embedable(replaced):
+            replaced_full = replaced
+            if url_is_embedable(replaced_full):
                 nonlocal changed
                 changed = True
-                return replaced
-            print(f"[LINK] cannot embed {replaced}, keeping {original}")
+                return replaced_full
+            print(f"[LINK] cannot embed {replaced_full}, keeping {original}")
             return original
 
         return _sub

--- a/test.py
+++ b/test.py
@@ -3972,8 +3972,20 @@ def test_replace_links_checks_preview(monkeypatch):
     text, changed = replace_links("https://x.com/foo")
     assert text == "https://fixupx.com/foo"
     assert changed is True
-    mock_can.assert_called_once_with("https://fixupx.com")
+    mock_can.assert_called_once_with("https://fixupx.com/foo")
 
+
+@patch("api.index.requests.get")
+def test_xcom_link_replacement_with_metadata(mock_get):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "text/html"}
+    mock_response.text = "<meta property='og:title' content='foo'>"
+    mock_get.return_value = mock_response
+    fixed, changed = replace_links("https://x.com/foo")
+    assert changed is True
+    assert fixed == "https://fixupx.com/foo"
+    mock_get.assert_called_once_with("https://fixupx.com/foo", allow_redirects=True, timeout=5)
 
 def test_can_embed_url_logs_missing_meta(monkeypatch, capsys):
     from api.index import can_embed_url


### PR DESCRIPTION
## Summary
- Ensure `replace_links` checks embed metadata for the full URL path on all supported social domains
- Update existing test to expect full URL checks and add regression test for `x.com` path replacement

## Testing
- `pytest -q` *(no tests found)*
- `pytest test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a842cf1924832eaecc562d26dd2f33