### PR TITLE
Ignore preview checks for original social links

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -41,6 +41,23 @@ ALTERNATIVE_FRONTENDS = {
     "vxtiktok.com",
 }
 
+# Original social domains that may need replacement
+ORIGINAL_FRONTENDS = {
+    "twitter.com",
+    "x.com",
+    "bsky.app",
+    "instagram.com",
+    "reddit.com",
+    "tiktok.com",
+}
+
+
+def is_social_frontend(host: str) -> bool:
+    """Return True if host is an original or alternative social frontend"""
+    host = host.lower()
+    frontends = ALTERNATIVE_FRONTENDS | ORIGINAL_FRONTENDS
+    return any(host == d or host.endswith(f".{d}") for d in frontends)
+
 
 def load_bot_config():
     """Load bot configuration from environment variables"""
@@ -2796,10 +2813,10 @@ def handle_msg(message: Dict) -> str:
             urls = re.findall(r"https?://\S+", message_text)
             if urls:
                 cleaned = [u.rstrip('.,!?') for u in urls]
-                remaining = []
+                remaining: List[str] = []
                 for u in cleaned:
                     host = urlparse(u).hostname
-                    if host and host.lower() not in ALTERNATIVE_FRONTENDS:
+                    if host and not is_social_frontend(host):
                         remaining.append(u)
                 if not remaining:
                     return "ok"

--- a/test.py
+++ b/test.py
@@ -4025,3 +4025,55 @@ def test_handle_msg_link_already_fixed():
         mock_send.assert_not_called()
         mock_should.assert_not_called()
         mock_get.assert_not_called()
+
+
+def test_handle_msg_original_link_no_check():
+    message = {
+        "message_id": 7,
+        "chat": {"id": 987, "type": "group"},
+        "from": {"id": 1},
+        "text": "https://vm.tiktok.com/foo",
+    }
+    with patch.dict("api.index.environ", {"TELEGRAM_USERNAME": "bot"}), \
+        patch("api.index.config_redis") as mock_redis, \
+        patch("api.index.send_msg") as mock_send, \
+        patch("api.index.initialize_commands", return_value={}), \
+        patch("api.index.should_gordo_respond") as mock_should, \
+        patch("api.index.replace_links") as mock_replace, \
+        patch("api.index.requests.get") as mock_get:
+        redis_client = MagicMock()
+        redis_client.get.return_value = "reply"
+        mock_redis.return_value = redis_client
+        mock_replace.return_value = ("https://vm.tiktok.com/foo", False)
+
+        result = handle_msg(message)
+
+        assert result == "ok"
+        mock_send.assert_not_called()
+        mock_should.assert_not_called()
+        mock_get.assert_not_called()
+
+
+def test_handle_msg_link_already_fixed_subdomain():
+    message = {
+        "message_id": 8,
+        "chat": {"id": 999, "type": "group"},
+        "from": {"id": 1},
+        "text": "https://vm.vxtiktok.com/foo",
+    }
+    with patch.dict("api.index.environ", {"TELEGRAM_USERNAME": "bot"}), \
+        patch("api.index.config_redis") as mock_redis, \
+        patch("api.index.send_msg") as mock_send, \
+        patch("api.index.initialize_commands", return_value={}), \
+        patch("api.index.should_gordo_respond") as mock_should, \
+        patch("api.index.requests.get") as mock_get:
+        redis_client = MagicMock()
+        redis_client.get.return_value = "reply"
+        mock_redis.return_value = redis_client
+
+        result = handle_msg(message)
+
+        assert result == "ok"
+        mock_send.assert_not_called()
+        mock_should.assert_not_called()
+        mock_get.assert_not_called()


### PR DESCRIPTION
## Summary
- skip embed checks for original social network domains and alternative frontends (including subdomains)
- ensure link handler ignores messages containing already replaced links
- add regression tests for these cases

## Testing
- `pytest test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8490495c0832ea3d1970032e59c6d