### PR TITLE
Add TCRM 100 to /dolar command

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask>=3.1.0
 openai>=1.57.3
 Pillow>=11.3.0
 ddgs>=9.5.2
+openpyxl>=3.1.5


### PR DESCRIPTION
## Summary
- compute ITCRM from BCRA spreadsheet and derive nominal rate for ITCRM=100
- include TCRM 100 among /dolar exchange rates
- cover TCRM calculation and output with unit tests

## Testing
- `pytest test.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be1ce255ac832ebf241867356bc529