### PR TITLE
Remove Tasa justicia from /bcra output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - `requirements.txt`: Python runtime dependencies.
 - `.env.example` / `.env`: Configuration template and local overrides (do not commit secrets).
 - `README.md`, `CLAUDE.md`: Usage and personality guidance.
+- BCRA economic variables are retrieved via the official BCRA API (helpers in `api/index.py`); avoid web scraping.
 
 ## Build, Test, and Development Commands
 - Create env: `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ python -m pytest test.py::test_handle_msg -v
 - `handle_msg()` - Main message processing pipeline at api/index.py:2166
 - `ask_ai()` - AI conversation handler at api/index.py:1184
 - `cached_requests()` - Generic API caching wrapper at api/index.py:115
-- `scrape_bcra_variables()` - BCRA economic data scraper at api/index.py:595
+- `get_or_refresh_bcra_variables()` - Fetches BCRA economic data via official API at api/index.py:1015
 - `handle_transcribe_with_message()` - Audio/image transcription handler at api/index.py:792
 
 ### Data Flow
@@ -64,7 +64,7 @@ python -m pytest test.py::test_handle_msg -v
 - **CriptoYa**: Argentine peso exchange rates
 - **OpenRouter**: AI model access (requires `OPENROUTER_API_KEY`)
 - **Cloudflare Workers AI**: Fallback AI and image/audio processing
-- **BCRA**: Economic variables web scraping from official page
+- **BCRA**: Economic variables retrieved through the official API (https://api.bcra.gob.ar/estadisticas/v4.0)
 - **Open-Meteo**: Weather data for Buenos Aires
 
 ### Environment Variables
@@ -97,11 +97,9 @@ Required environment variables are documented in README.md. Critical ones:
 ### Recent Major Features
 
 **BCRA Economic Data (/bcra, /variables):**
-- Web scraping from official BCRA website (https://www.bcra.gob.ar/PublicacionesEstadisticas/Principales_variables.asp)
-- Extracts 12 specific economic variables in precise order: Base monetaria, Inflación (mensual/interanual/esperada), TAMAR, BADLAR, Tasa justicia, Dólar (minorista/mayorista), UVA, CER, Reservas
-- Handles special HTML table formats including 5-column header rows for reservas data
-- 5-minute Redis caching for performance
-- SSL certificate bypass and encoding handling (iso-8859-1)
+- Uses the official BCRA statistics API (https://api.bcra.gob.ar/estadisticas/v4.0)
+- Extracts 11 key variables: Base monetaria, Inflación (mensual/interanual/esperada), TAMAR, BADLAR, Dólar (minorista/mayorista), UVA, CER, Reservas
+- Caches responses in Redis for 5 minutes and persists Dólar Mayorista history
 
 **Audio/Image Transcription (/transcribe):**
 - Must be used as reply to messages containing audio, images, or stickers

--- a/api/index.py
+++ b/api/index.py
@@ -1320,7 +1320,6 @@ def format_bcra_variables(variables: Dict) -> str:
         # Tasas
         (r"tamar", lambda v: f"📈 TAMAR: {format_value(v, True)}"),
         (r"badlar", lambda v: f"📊 BADLAR: {format_value(v, True)}"),
-        (r"tasa.*interes.*justicia", lambda v: f"⚖️ Tasa justicia: {v}%"),
         # Tipo de cambio
         (r"tipo.*cambio.*minorista|minorista.*promedio.*vendedor", lambda v: f"💵 Dólar minorista: ${v}"),
         (r"tipo.*cambio.*mayorista", lambda v: f"💱 Dólar mayorista: ${v}"),

--- a/test.py
+++ b/test.py
@@ -2524,7 +2524,6 @@ def test_format_bcra_variables_with_data():
         "inflacion_esperada": {"value": "3,1", "date": "15/01/2025"},
         "tasa_tamar": {"value": "45,0", "date": "15/01/2025"},
         "tasa_badlar": {"value": "40,5", "date": "15/01/2025"},
-        "tasa_justicia": {"value": "50,0", "date": "15/01/2025"},
         "dolar_minorista_compra": {"value": "1.200,50", "date": "15/01/2025"},
         "dolar_minorista_venta": {"value": "1.250,75", "date": "15/01/2025"},
         "dolar_mayorista": {"value": "1.180,25", "date": "15/01/2025"},


### PR DESCRIPTION
## Summary
- drop Tasa justicia from BCRA variable formatting so /bcra no longer shows it
- adjust tests and documentation to match removal
- clarify in AGENTS and CLAUDE docs that BCRA data comes from the official API instead of scraping

## Testing
- `pytest -q test.py`


------
https://chatgpt.com/codex/tasks/task_e_68c085b48f5c832c976aaa14e1f1a145