### PR TITLE
Add fetch_url tool for arbitrary browsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This bot is configured entirely through environment variables, making it easy to
 - En conversaciones de IA, el bot puede decidir usar la herramienta `web_search` cuando necesita datos actuales. El modelo pedirá la herramienta escribiendo una línea como:
   `[TOOL] web_search {"query": "inflación argentina hoy"}`
   y luego responderá usando los resultados.
+- También puede pedir leer una página puntual con la herramienta `fetch_url`, que descarga cualquier URL http/https y devuelve el texto plano para que el bot cite fragmentos en sus respuestas o cuando opera como agente autónomo.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- add a new fetch_url tool that normalizes URLs, fetches page content and exposes it through execute_tool and agent fallbacks
- advertise the new capability in the agent prompt, system message and README so the model knows when to read full pages
- cover the new tool with unit tests for the fetch helper and execute_tool wiring

## Testing
- pytest test.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca287844bc832ca306e4ee1c9f00b5