### PR TITLE
Limit /agent output to five entries and add CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.x"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest
+
+      - name: Run test suite
+        run: python -m pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,4 +26,4 @@ jobs:
           pip install -r requirements.txt pytest
 
       - name: Run test suite
-        run: python -m pytest -q
+        run: python -m pytest -q test.py

--- a/api/index.py
+++ b/api/index.py
@@ -46,6 +46,7 @@ TTL_MEDIA_CACHE = 7 * 24 * 60 * 60  # 7 days
 # Autonomous agent thought logging
 AGENT_THOUGHTS_KEY = "agent:thoughts"
 MAX_AGENT_THOUGHTS = 10
+AGENT_THOUGHT_DISPLAY_LIMIT = 5
 AGENT_THOUGHT_CHAR_LIMIT = 500
 AGENT_RECENT_THOUGHT_WINDOW = 5
 AGENT_REQUIRED_SECTIONS = ("HALLAZGOS", "PRÓXIMO PASO")
@@ -704,7 +705,8 @@ def show_agent_thoughts() -> str:
     """Expose stored thoughts through the /agent command."""
 
     thoughts = get_agent_thoughts()
-    return format_agent_thoughts(thoughts)
+    visible_thoughts = thoughts[:AGENT_THOUGHT_DISPLAY_LIMIT]
+    return format_agent_thoughts(visible_thoughts)
 
 
 def run_agent_cycle() -> Dict[str, Any]:

--- a/test.py
+++ b/test.py
@@ -698,6 +698,21 @@ def test_show_agent_thoughts_no_entries():
     assert "no tengo pensamientos" in response
 
 
+def test_show_agent_thoughts_limits_entries():
+    from api.index import show_agent_thoughts, AGENT_THOUGHT_DISPLAY_LIMIT
+
+    sample = [{"text": f"nota {i}"} for i in range(1, AGENT_THOUGHT_DISPLAY_LIMIT + 3)]
+
+    with patch("api.index.get_agent_thoughts", return_value=sample):
+        response = show_agent_thoughts()
+
+    for i in range(1, AGENT_THOUGHT_DISPLAY_LIMIT + 1):
+        assert f"nota {i}" in response
+
+    assert f"nota {AGENT_THOUGHT_DISPLAY_LIMIT + 1}" not in response
+    assert f"nota {AGENT_THOUGHT_DISPLAY_LIMIT + 2}" not in response
+
+
 def test_run_agent_cycle_returns_result():
     from api.index import run_agent_cycle
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies and runs the pytest suite in CI
- cap the /agent command to display only the five most recent stored thoughts
- add a regression test covering the /agent output limit

## Testing
- pytest -q test.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8d88aa68832ca2edc542ef0c0c93