### PR TITLE
Avoid recursive fallback loops

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -814,9 +814,24 @@ def build_agent_retry_prompt(previous_text: Optional[str]) -> str:
 def build_agent_fallback_entry(previous_text: Optional[str]) -> str:
     """Generate a non-repetitive fallback entry when the agent keeps looping."""
 
-    preview = truncate_text(previous_text or "", 120)
+    sanitized_previous = (previous_text or "").strip()
+    normalized_previous = normalize_agent_text(sanitized_previous)
+    fallback_marker = normalize_agent_text(
+        "HALLAZGOS: registré que estaba en un loop repitiendo"
+    )
+
+    preview = truncate_text(sanitized_previous, 120)
     preview_single_line = preview.replace("\n", " ").strip()
-    loop_fragment = f' "{preview_single_line}"' if preview_single_line else ""
+
+    include_fragment = True
+    if normalized_previous and fallback_marker and normalized_previous.startswith(
+        fallback_marker
+    ):
+        include_fragment = False
+
+    loop_fragment = (
+        f' "{preview_single_line}"' if include_fragment and preview_single_line else ""
+    )
     return (
         "HALLAZGOS: registré que estaba en un loop repitiendo"
         f"{loop_fragment} sin generar avances reales.\n"

--- a/test.py
+++ b/test.py
@@ -4873,3 +4873,15 @@ def test_build_agent_fallback_entry_mentions_loop_and_previous():
 
     assert "loop" in fallback
     assert previous in fallback
+
+
+def test_build_agent_fallback_entry_avoids_recursive_quote():
+    previous = (
+        "HALLAZGOS: registré que estaba en un loop repitiendo \"algo viejo\" sin generar avances reales.\n"
+        "PRÓXIMO PASO: hacer una búsqueda web urgente, anotar los datos específicos que salgan y recién después planear el próximo paso."
+    )
+
+    fallback = build_agent_fallback_entry(previous)
+
+    assert "loop" in fallback
+    assert previous not in fallback


### PR DESCRIPTION
## Summary
- prevent the autonomous agent fallback from quoting previous fallback entries, avoiding infinite self-references
- add a regression test covering the fallback loop handling

## Testing
- pytest -q test.py

------
https://chatgpt.com/codex/tasks/task_e_68ca97d1e2f0832cbd55678e03b07c8e