### PR TITLE
Normalize agent section header matching

### DIFF
--- a/test.py
+++ b/test.py
@@ -28,6 +28,7 @@ from api.index import (
     build_agent_retry_prompt,
     build_agent_fallback_entry,
     summarize_recent_agent_topics,
+    agent_sections_are_valid,
 )
 from datetime import datetime, timezone, timedelta
 import json
@@ -5009,3 +5010,21 @@ def test_build_agent_fallback_entry_avoids_recursive_quote():
 
     assert "loop" in fallback
     assert previous not in fallback
+
+
+def test_agent_sections_are_valid_accepts_accented_headers():
+    text = (
+        "HALLAZGOS: repasé ligas europeas de fútbol femenino.\n"
+        "PRÓXIMO PASO: buscar calendario local"
+    )
+
+    assert agent_sections_are_valid(text)
+
+
+def test_agent_sections_are_valid_accepts_unaccented_headers():
+    text = (
+        "HALLAZGOS: repasé ligas europeas de fútbol femenino.\n"
+        "PROXIMO PASO: buscar calendario local"
+    )
+
+    assert agent_sections_are_valid(text)


### PR DESCRIPTION
## Summary
- normalize the agent section parser by removing diacritics and keeping index mappings so accented headers match consistently
- reuse the normalized header set when searching for the next section to avoid misses
- add coverage to ensure `agent_sections_are_valid` accepts accented and unaccented headers

## Testing
- pytest test.py -q

------
https://chatgpt.com/codex/tasks/task_e_68caa25a7760832c9f5720e4f7596e66