### PR TITLE
Intensify agent retry randomness

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -11,6 +11,7 @@ from requests.exceptions import RequestException, SSLError
 from urllib3.exceptions import InsecureRequestWarning
 import warnings
 from typing import Dict, List, Tuple, Callable, Union, Optional, Any, cast, Set, Iterable
+from collections import Counter
 from difflib import SequenceMatcher
 import ast
 import base64
@@ -1078,12 +1079,109 @@ def agent_sections_are_valid(text: str) -> bool:
     return True
 
 
-def build_agent_retry_prompt(previous_text: Optional[str]) -> str:
+def get_agent_retry_hint(
+    previous_text: Optional[str], rng: Optional[random.Random] = None
+) -> str:
+    """Return a randomized thinking prompt so the agent explores nuevos datos."""
+
+    normalized_previous = normalize_agent_text(previous_text or "")
+    tokens = [token for token in normalized_previous.split() if token]
+
+    filtered_tokens: List[str] = []
+    for token in tokens:
+        if token in AGENT_KEYWORD_STOPWORDS:
+            continue
+        if len(token) < 3:
+            continue
+        if token.isdigit():
+            continue
+        filtered_tokens.append(token)
+
+    keyword_counter = Counter(filtered_tokens)
+    top_keywords: List[str] = [word for word, _ in keyword_counter.most_common(3)]
+
+    if top_keywords:
+        avoided_fragment = (
+            "Marcá como prohibidos estos términos ya gastados: "
+            + ", ".join(top_keywords)
+            + ". "
+        )
+    else:
+        avoided_fragment = "Arrancá desde cero sin reciclar la última búsqueda. "
+
+    rng_instance = rng if rng is not None else random
+
+    option_count = rng_instance.randint(3, 4)
+    ordinal_words = ("primera", "segunda", "tercera", "cuarta", "quinta")
+    ordinal_index = rng_instance.randint(0, option_count - 1)
+    ordinal_word = ordinal_words[min(ordinal_index, len(ordinal_words) - 1)]
+
+    brainstorming_templates = (
+        "Anotá {n} búsquedas frescas en temas distintos. Ejecutá la {ordinal} con web_search.",
+        "Hacé una mini lluvia de ideas con {n} queries nuevos y corré la {ordinal} usando web_search.",
+        "Pensá en {n} consultas posibles que sorprendan al gordo y quedate con la {ordinal} para web_search.",
+    )
+
+    follow_up_templates = (
+        "Traé números, fechas y citá la fuente puntual.",
+        "Resumí el dato clave con cifras concretas y quién lo publicó.",
+        "Documentá resultados verificables (monto, variación, protagonista) y la fuente exacta.",
+    )
+
+    brainstorming_prompt = rng_instance.choice(brainstorming_templates).format(
+        n=option_count,
+        ordinal=ordinal_word,
+    )
+    follow_up_prompt = rng_instance.choice(follow_up_templates)
+
+    letter_choices = tuple("abcdefghijklmnñopqrstuvwxyz")
+    chosen_letter = rng_instance.choice(letter_choices).upper()
+    alternate_pool = [value for value in letter_choices if value.upper() != chosen_letter]
+    fallback_letter = (
+        rng_instance.choice(alternate_pool).upper() if alternate_pool else chosen_letter
+    )
+
+    numeric_floor = rng_instance.randint(8, 24)
+    numeric_multiplier = rng_instance.randint(3, 9)
+    numeric_target = numeric_floor * numeric_multiplier
+
+    constraint_templates = (
+        "Sumá una restricción creativa: la búsqueda tiene que incluir un protagonista cuya inicial sea \"{letter}\" y una cifra cerca de {value}.",
+        "Obligate a que la consulta nombre algo que empiece con \"{letter}\" y mencione un número alrededor de {value}.",
+        "Forzá el query a combinar un actor que arranque con \"{letter}\" más un dato numérico aproximado a {value}.",
+    )
+
+    pivot_templates = (
+        "Si web_search no trae novedad, generá otra lluvia de ideas reemplazando las palabras prohibidas por categorías nuevas y probá con inicial \"{fallback}\".",
+        "Si la ejecución devuelve humo, descartá la idea y repetí el proceso con términos distintos que comiencen con \"{fallback}\".",
+        "Si no aparecen datos frescos, reseteá las keywords vetadas y buscá una consulta distinta arrancando por \"{fallback}\".",
+    )
+
+    constraint_prompt = rng_instance.choice(constraint_templates).format(
+        letter=chosen_letter, value=numeric_target
+    )
+    pivot_prompt = rng_instance.choice(pivot_templates).format(fallback=fallback_letter)
+
+    return (
+        avoided_fragment
+        + brainstorming_prompt
+        + " "
+        + follow_up_prompt
+        + " "
+        + constraint_prompt
+        + " "
+        + pivot_prompt
+    )
+
+
+def build_agent_retry_prompt(
+    previous_text: Optional[str], rng: Optional[random.Random] = None
+) -> str:
     """Create a corrective prompt so the agent avoids looping."""
 
     preview = truncate_text(previous_text or "", 160)
     preview_single_line = preview.replace("\n", " ").strip()
-    return (
+    base_prompt = (
         "La última nota no sirvió: te repetiste igual que la memoria anterior o no respetaste la estructura obligatoria. "
         "Antes de escribir otra vez, completá el pendiente y contá resultados concretos. "
         "Si necesitás info fresca, llamá a la herramienta web_search con un query preciso y resumí lo que encontraste. Si ya cerraste ese tema, cambiá a otro interés fuerte del gordo en vez de seguir clavado en lo mismo. "
@@ -1095,6 +1193,11 @@ def build_agent_retry_prompt(previous_text: Optional[str]) -> str:
         + "Escribí ahora una nota distinta con hechos puntuales y cerrala en dos secciones claras: "
         "\"HALLAZGOS:\" con los datos específicos que obtuviste y \"PRÓXIMO PASO:\" con la siguiente acción directa."
     )
+
+    hint = get_agent_retry_hint(previous_text, rng=rng)
+    if hint:
+        return f"{base_prompt} {hint}"
+    return base_prompt
 
 
 def build_agent_fallback_entry(previous_text: Optional[str]) -> str:


### PR DESCRIPTION
## Summary
- extend `get_agent_retry_hint` so each retry injects letter-based and numeric constraints plus a fallback pivot to enforce brand new search angles
- tighten the retry prompt tests to check for the extra randomness by asserting digit and letter requirements in the generated guidance

## Testing
- pytest -q
- pytest -q test.py::test_build_agent_retry_prompt_adds_dynamic_guidance
- pytest -q test.py::test_get_agent_retry_hint_references_previous_keywords
- pytest -q test.py::test_get_agent_retry_hint_varies_with_random_seed

------
https://chatgpt.com/codex/tasks/task_e_68cd85aa2a14832c8365cd8924e49f6d