### PR TITLE
Document /agent command in help

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -3250,6 +3250,8 @@ comandos disponibles boludo:
 
 - /buscar algo: te busco en la web
 
+- /agent: te muestro lo ultimo que penso el agente autonomo
+
 - /devo 0.5, 100: te calculo el arbitraje entre tarjeta y crypto (fee%, monto opcional)
 
 - /dolar, /dollar, /usd: te tiro la posta del blue y todos los dolares


### PR DESCRIPTION
## Summary
- add the /agent command to the help text so users can discover it

## Testing
- pytest test.py

------
https://chatgpt.com/codex/tasks/task_e_68d457d1a8f0832cb5853e08a848ff89