### PR TITLE
feat: add YouTube transcript extraction for bot responses

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -3642,6 +3642,7 @@ def _log_groq_request_result(
     account: str,
     token_count: int,
     audio_seconds: float,
+
     result: Optional[AIUsageResult],
 ) -> None:
     log_entry: Dict[str, Any] = {
@@ -3651,6 +3652,7 @@ def _log_groq_request_result(
         "account": account,
         "estimated_token_count": int(max(0, token_count)),
         "estimated_audio_seconds": float(max(0.0, audio_seconds)),
+
         "status": "success" if result else "empty",
     }
 
@@ -5025,8 +5027,7 @@ def _describe_image_groq_result(
 
     def _attempt(account: str) -> Optional[AIUsageResult]:
         groq_client = _get_groq_client(account)
-        if groq_client is None:
-            return None
+        if groq_client is None: return None
         print(f"Describing image with Groq vision model using account={account}...")
         input_payload = cast(
             ResponseInputParam,
@@ -5245,10 +5246,9 @@ def _transcribe_audio_result(
 
     def _attempt(account: str) -> Optional[AIUsageResult]:
         native_client = _get_groq_native_client(account)
-        if native_client is None:
-            return None
+        if native_client is None: return None
         print(f"Transcribing audio with Groq Whisper using account={account}...")
-
+        
         audio_file = io.BytesIO(audio_data)
         audio_file.name = "audio.webm"
         response = native_client.audio.transcriptions.create(
@@ -5260,7 +5260,7 @@ def _transcribe_audio_result(
             transcription = response.get("text")
         else:
             transcription = getattr(response, "text", None)
-
+        
         if transcription:
             print(f"Audio transcribed successfully: {transcription[:100]}...")
             return _build_groq_usage_result(
@@ -5373,7 +5373,9 @@ def transcribe_file_by_id(
             if duration_seconds is None:
                 return None, "duration", None
 
-        result = _transcribe_audio_result(media_bytes, file_id, use_cache=use_cache)
+        result = _transcribe_audio_result(
+            media_bytes, file_id, use_cache=use_cache
+        )
         if result:
             if not result.audio_seconds:
                 result.audio_seconds = duration_seconds

--- a/api/index.py
+++ b/api/index.py
@@ -167,6 +167,10 @@ from api.utils.links import (
     replace_links as _links_replace_links,
     fetch_tweet_text as _links_fetch_tweet_text,
 )
+from api.utils.youtube_transcript import (
+    extract_youtube_video_id,
+    get_youtube_transcript_context,
+)
 
 # TTL constants (seconds)
 TTL_PRICE = 300  # 5 minutes
@@ -3377,6 +3381,8 @@ def build_message_links_context(message: Mapping[str, Any]) -> str:
     print(f"build_message_links_context: extracted {len(urls)} url(s) urls={urls}")
 
     lines = ["LINKS DEL MENSAJE:"]
+    transcript_parts: List[str] = []
+
     for index, url in enumerate(urls, 1):
         metadata = fetch_link_metadata(url)
         final_url = str(metadata.get("url") or url).strip() or url
@@ -3389,6 +3395,17 @@ def build_message_links_context(message: Mapping[str, Any]) -> str:
             lines.append(f"titulo: {title}")
         if description:
             lines.append(f"descripcion: {description}")
+
+        video_id = extract_youtube_video_id(final_url)
+        if video_id:
+            transcript = get_youtube_transcript_context(video_id)
+            if transcript:
+                transcript_parts.append(transcript)
+
+    if transcript_parts:
+        lines.append("")
+        lines.extend(transcript_parts)
+
     return "\n".join(lines)
 
 
@@ -3625,7 +3642,6 @@ def _log_groq_request_result(
     account: str,
     token_count: int,
     audio_seconds: float,
-
     result: Optional[AIUsageResult],
 ) -> None:
     log_entry: Dict[str, Any] = {
@@ -3635,7 +3651,6 @@ def _log_groq_request_result(
         "account": account,
         "estimated_token_count": int(max(0, token_count)),
         "estimated_audio_seconds": float(max(0.0, audio_seconds)),
-
         "status": "success" if result else "empty",
     }
 
@@ -5010,7 +5025,8 @@ def _describe_image_groq_result(
 
     def _attempt(account: str) -> Optional[AIUsageResult]:
         groq_client = _get_groq_client(account)
-        if groq_client is None: return None
+        if groq_client is None:
+            return None
         print(f"Describing image with Groq vision model using account={account}...")
         input_payload = cast(
             ResponseInputParam,
@@ -5229,9 +5245,10 @@ def _transcribe_audio_result(
 
     def _attempt(account: str) -> Optional[AIUsageResult]:
         native_client = _get_groq_native_client(account)
-        if native_client is None: return None
+        if native_client is None:
+            return None
         print(f"Transcribing audio with Groq Whisper using account={account}...")
-        
+
         audio_file = io.BytesIO(audio_data)
         audio_file.name = "audio.webm"
         response = native_client.audio.transcriptions.create(
@@ -5243,7 +5260,7 @@ def _transcribe_audio_result(
             transcription = response.get("text")
         else:
             transcription = getattr(response, "text", None)
-            
+
         if transcription:
             print(f"Audio transcribed successfully: {transcription[:100]}...")
             return _build_groq_usage_result(
@@ -5275,6 +5292,7 @@ def _transcribe_audio_result(
         cache_transcription(file_id, result.text)
 
     return result
+
 
 def transcribe_audio_groq(
     audio_data: bytes,
@@ -5355,9 +5373,7 @@ def transcribe_file_by_id(
             if duration_seconds is None:
                 return None, "duration", None
 
-        result = _transcribe_audio_result(
-            media_bytes, file_id, use_cache=use_cache
-        )
+        result = _transcribe_audio_result(media_bytes, file_id, use_cache=use_cache)
         if result:
             if not result.audio_seconds:
                 result.audio_seconds = duration_seconds

--- a/api/utils/__init__.py
+++ b/api/utils/__init__.py
@@ -21,6 +21,13 @@ from api.utils.links import (
     fetch_tweet_via_oembed,
     fetch_tweet_text,
 )
+from api.utils.youtube_transcript import (
+    extract_youtube_video_id,
+    is_youtube_url,
+    fetch_youtube_transcript,
+    format_youtube_transcript_for_context,
+    get_youtube_transcript_context,
+)
 
 __all__ = [
     "fmt_num",
@@ -42,4 +49,9 @@ __all__ = [
     "extract_tweet_urls",
     "fetch_tweet_via_oembed",
     "fetch_tweet_text",
+    "extract_youtube_video_id",
+    "is_youtube_url",
+    "fetch_youtube_transcript",
+    "format_youtube_transcript_for_context",
+    "get_youtube_transcript_context",
 ]

--- a/api/utils/__init__.py
+++ b/api/utils/__init__.py
@@ -23,7 +23,6 @@ from api.utils.links import (
 )
 from api.utils.youtube_transcript import (
     extract_youtube_video_id,
-    is_youtube_url,
     fetch_youtube_transcript,
     format_youtube_transcript_for_context,
     get_youtube_transcript_context,
@@ -50,7 +49,6 @@ __all__ = [
     "fetch_tweet_via_oembed",
     "fetch_tweet_text",
     "extract_youtube_video_id",
-    "is_youtube_url",
     "fetch_youtube_transcript",
     "format_youtube_transcript_for_context",
     "get_youtube_transcript_context",

--- a/api/utils/youtube_transcript.py
+++ b/api/utils/youtube_transcript.py
@@ -1,0 +1,194 @@
+"""YouTube transcript extraction utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api._errors import (
+    CouldNotRetrieveTranscript,
+    TranscriptsDisabled,
+    NoTranscriptFound,
+    VideoUnavailable,
+)
+
+__all__ = [
+    "extract_youtube_video_id",
+    "is_youtube_url",
+    "fetch_youtube_transcript",
+    "format_youtube_transcript_for_context",
+    "get_youtube_transcript_context",
+]
+
+
+YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "youtu.be",
+    "www.youtu.be",
+}
+
+YOUTUBE_REGEX = re.compile(
+    r"(?:https?://)?(?:"
+    r"(?:www\.)?youtube\.com(?:/[^/\s]+)*"
+    r"|"
+    r"youtu\.be"
+    r")"
+    r"(?:/[^\s]*)?"
+)
+
+
+def extract_youtube_video_id(url: str) -> Optional[str]:
+    """Extract the 11-character video ID from a YouTube URL.
+
+    Supports:
+    - https://www.youtube.com/watch?v=VIDEO_ID
+    - https://youtube.com/watch?v=VIDEO_ID
+    - https://youtu.be/VIDEO_ID
+    - https://www.youtube.com/embed/VIDEO_ID
+    - https://www.youtube.com/v/VIDEO_ID
+    - Shorts URLs, live URLs, etc.
+    """
+    if not url:
+        return None
+
+    parsed_url = re.search(
+        r"(?:v=|/v/|/embed/|/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})",
+        url,
+    )
+    if parsed_url:
+        return parsed_url.group(1)
+
+    return None
+
+
+def is_youtube_url(url: str) -> bool:
+    """Return True if the URL is a YouTube video URL."""
+    if not url:
+        return False
+
+    video_id = extract_youtube_video_id(url)
+    if video_id:
+        return True
+
+    url_lower = url.lower()
+    return any(host in url_lower for host in YOUTUBE_HOSTS)
+
+
+def fetch_youtube_transcript(
+    video_id: str,
+    languages: List[str] = None,
+) -> Tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    """Fetch transcript for a YouTube video.
+
+    Args:
+        video_id: The 11-character YouTube video ID.
+        languages: Preferred languages in order of preference. Defaults to ['en', 'es'].
+
+    Returns:
+        Tuple of (transcript_list, error_message). transcript_list is None if
+        fetching failed. error_message is None on success.
+    """
+    if languages is None:
+        languages = ["en", "es"]
+
+    try:
+        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+
+        try:
+            transcript = transcript_list.find_transcript(languages)
+        except Exception:
+            try:
+                transcript = transcript_list.find_transcript(["en"])
+            except Exception:
+                try:
+                    transcript = transcript_list.find_transcript(["es"])
+                except Exception:
+                    try:
+                        transcript = transcript_list.find_generated_transcript(
+                            languages
+                        )
+                    except Exception:
+                        return None, "no transcript found"
+
+        fetched_transcript = transcript.fetch()
+        return fetched_transcript, None
+
+    except VideoUnavailable:
+        return None, "video unavailable"
+    except TranscriptsDisabled:
+        return None, "transcripts disabled"
+    except NoTranscriptFound:
+        return None, "no transcript found"
+    except CouldNotRetrieveTranscript as e:
+        print(f"[YOUTUBE_TRANSCRIPT] CouldNotRetrieveTranscript: {e}")
+        return None, "could not retrieve transcript"
+    except Exception as e:
+        print(f"[YOUTUBE_TRANSCRIPT] Unexpected error: {e}")
+        return None, f"error: {str(e)}"
+
+
+def format_youtube_transcript_for_context(
+    transcript: List[Dict[str, Any]],
+    include_timestamps: bool = True,
+) -> str:
+    """Format a YouTube transcript for AI context.
+
+    Args:
+        transcript: List of transcript segments from youtube-transcript-api.
+        include_timestamps: If True, include [MM:SS] timestamps before each segment.
+
+    Returns:
+        Formatted transcript string.
+    """
+    if not transcript:
+        return ""
+
+    lines = []
+    for segment in transcript:
+        start = segment.get("start", 0)
+        text = segment.get("text", "").strip()
+
+        if not text:
+            continue
+
+        if include_timestamps:
+            minutes = int(start) // 60
+            seconds = int(start) % 60
+            timestamp = f"[{minutes:02d}:{seconds:02d}]"
+            lines.append(f"{timestamp} {text}")
+        else:
+            lines.append(text)
+
+    return "\n".join(lines)
+
+
+def get_youtube_transcript_context(
+    video_id: str,
+    languages: List[str] = None,
+) -> str:
+    """Get formatted transcript context for a YouTube video.
+
+    Args:
+        video_id: The 11-character YouTube video ID.
+        languages: Preferred languages in order of preference.
+
+    Returns:
+        Formatted transcript string, or empty string if fetching failed.
+    """
+    transcript, error = fetch_youtube_transcript(video_id, languages)
+
+    if error or not transcript:
+        print(
+            f"[YOUTUBE_TRANSCRIPT] Failed to fetch transcript for {video_id}: {error}"
+        )
+        return ""
+
+    formatted = format_youtube_transcript_for_context(transcript)
+
+    if not formatted:
+        return ""
+
+    return f"TRANSCRIPCION DEL VIDEO:\n{formatted}"

--- a/api/utils/youtube_transcript.py
+++ b/api/utils/youtube_transcript.py
@@ -21,15 +21,6 @@ __all__ = [
 ]
 
 
-YOUTUBE_HOSTS = {
-    "youtube.com",
-    "www.youtube.com",
-    "m.youtube.com",
-    "youtu.be",
-    "www.youtu.be",
-}
-
-
 def extract_youtube_video_id(url: str) -> Optional[str]:
     """Extract the 11-character video ID from a YouTube URL.
 

--- a/api/utils/youtube_transcript.py
+++ b/api/utils/youtube_transcript.py
@@ -15,7 +15,6 @@ from youtube_transcript_api._errors import (
 
 __all__ = [
     "extract_youtube_video_id",
-    "is_youtube_url",
     "fetch_youtube_transcript",
     "format_youtube_transcript_for_context",
     "get_youtube_transcript_context",
@@ -29,15 +28,6 @@ YOUTUBE_HOSTS = {
     "youtu.be",
     "www.youtu.be",
 }
-
-YOUTUBE_REGEX = re.compile(
-    r"(?:https?://)?(?:"
-    r"(?:www\.)?youtube\.com(?:/[^/\s]+)*"
-    r"|"
-    r"youtu\.be"
-    r")"
-    r"(?:/[^\s]*)?"
-)
 
 
 def extract_youtube_video_id(url: str) -> Optional[str]:
@@ -55,26 +45,13 @@ def extract_youtube_video_id(url: str) -> Optional[str]:
         return None
 
     parsed_url = re.search(
-        r"(?:v=|/v/|/embed/|/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})",
+        r"(?:v=|/v/|/embed/|/shorts/|/watch\?v=|youtu\.be/)([a-zA-Z0-9_-]{11})",
         url,
     )
     if parsed_url:
         return parsed_url.group(1)
 
     return None
-
-
-def is_youtube_url(url: str) -> bool:
-    """Return True if the URL is a YouTube video URL."""
-    if not url:
-        return False
-
-    video_id = extract_youtube_video_id(url)
-    if video_id:
-        return True
-
-    url_lower = url.lower()
-    return any(host in url_lower for host in YOUTUBE_HOSTS)
 
 
 def fetch_youtube_transcript(

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ psycopg[binary]>=3.3.3
 mutagen>=1.47.0
 python-telegram-bot>=22.7,<23.0
 APScheduler>=3.10.4,<4.0
+youtube-transcript-api>=0.2.2

--- a/tests/test_youtube_transcript.py
+++ b/tests/test_youtube_transcript.py
@@ -120,9 +120,18 @@ class TestFetchYouTubeTranscript:
     def test_no_transcript_found(self, mock_yta):
         from youtube_transcript_api._errors import NoTranscriptFound
 
-        mock_yta.list_transcripts.side_effect = NoTranscriptFound(
-            "No transcript available"
+        mock_list = MagicMock()
+        mock_list.find_transcript.side_effect = NoTranscriptFound(
+            "dQw4w9WgXcQ",
+            ["en", "es"],
+            mock_list,
         )
+        mock_list.find_generated_transcript.side_effect = NoTranscriptFound(
+            "dQw4w9WgXcQ",
+            ["en", "es"],
+            mock_list,
+        )
+        mock_yta.list_transcripts.return_value = mock_list
 
         transcript, error = fetch_youtube_transcript("dQw4w9WgXcQ")
 

--- a/tests/test_youtube_transcript.py
+++ b/tests/test_youtube_transcript.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, MagicMock
 
 from api.utils.youtube_transcript import (

--- a/tests/test_youtube_transcript.py
+++ b/tests/test_youtube_transcript.py
@@ -3,7 +3,6 @@ from unittest.mock import patch, MagicMock
 
 from api.utils.youtube_transcript import (
     extract_youtube_video_id,
-    is_youtube_url,
     fetch_youtube_transcript,
     format_youtube_transcript_for_context,
     get_youtube_transcript_context,
@@ -53,22 +52,6 @@ class TestExtractVideoId:
     def test_non_youtube_url_returns_none(self):
         assert extract_youtube_video_id("https://www.google.com") is None
         assert extract_youtube_video_id("https://vimeo.com/123456789") is None
-
-
-class TestIsYoutubeUrl:
-    def test_standard_youtube_url(self):
-        assert is_youtube_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is True
-
-    def test_youtu_be_url(self):
-        assert is_youtube_url("https://youtu.be/dQw4w9WgXcQ") is True
-
-    def test_non_youtube_url(self):
-        assert is_youtube_url("https://www.google.com") is False
-        assert is_youtube_url("https://vimeo.com/123456789") is False
-
-    def test_empty_url(self):
-        assert is_youtube_url("") is False
-        assert is_youtube_url(None) is False
 
 
 class TestFormatTranscriptForContext:

--- a/tests/test_youtube_transcript.py
+++ b/tests/test_youtube_transcript.py
@@ -1,0 +1,193 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+from api.utils.youtube_transcript import (
+    extract_youtube_video_id,
+    is_youtube_url,
+    fetch_youtube_transcript,
+    format_youtube_transcript_for_context,
+    get_youtube_transcript_context,
+)
+
+
+class TestExtractVideoId:
+    def test_standard_watch_url(self):
+        assert (
+            extract_youtube_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_short_youtu_be_url(self):
+        assert extract_youtube_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+
+    def test_embedded_url(self):
+        assert (
+            extract_youtube_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_short_url(self):
+        assert (
+            extract_youtube_video_id("https://youtube.com/shorts/dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_youtube_url_with_extra_params(self):
+        assert (
+            extract_youtube_video_id(
+                "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+            )
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_mobile_url(self):
+        assert (
+            extract_youtube_video_id("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
+            == "dQw4w9WgXcQ"
+        )
+
+    def test_no_url_returns_none(self):
+        assert extract_youtube_video_id("") is None
+        assert extract_youtube_video_id(None) is None
+
+    def test_non_youtube_url_returns_none(self):
+        assert extract_youtube_video_id("https://www.google.com") is None
+        assert extract_youtube_video_id("https://vimeo.com/123456789") is None
+
+
+class TestIsYoutubeUrl:
+    def test_standard_youtube_url(self):
+        assert is_youtube_url("https://www.youtube.com/watch?v=dQw4w9WgXcQ") is True
+
+    def test_youtu_be_url(self):
+        assert is_youtube_url("https://youtu.be/dQw4w9WgXcQ") is True
+
+    def test_non_youtube_url(self):
+        assert is_youtube_url("https://www.google.com") is False
+        assert is_youtube_url("https://vimeo.com/123456789") is False
+
+    def test_empty_url(self):
+        assert is_youtube_url("") is False
+        assert is_youtube_url(None) is False
+
+
+class TestFormatTranscriptForContext:
+    def test_format_with_timestamps(self):
+        transcript = [
+            {"start": 0.0, "text": "Hello world"},
+            {"start": 5.5, "text": "This is a test"},
+            {"start": 120.3, "text": "Two minutes in"},
+        ]
+        result = format_youtube_transcript_for_context(transcript)
+
+        assert "[00:00] Hello world" in result
+        assert "[00:05] This is a test" in result
+        assert "[02:00] Two minutes in" in result
+
+    def test_format_without_timestamps(self):
+        transcript = [
+            {"start": 0.0, "text": "Hello world"},
+            {"start": 5.5, "text": "This is a test"},
+        ]
+        result = format_youtube_transcript_for_context(
+            transcript, include_timestamps=False
+        )
+
+        assert "Hello world" in result
+        assert "This is a test" in result
+        assert "[00:00]" not in result
+
+    def test_empty_transcript(self):
+        assert format_youtube_transcript_for_context([]) == ""
+
+    def test_skips_empty_text_segments(self):
+        transcript = [
+            {"start": 0.0, "text": "Hello"},
+            {"start": 1.0, "text": ""},
+            {"start": 2.0, "text": "  "},
+            {"start": 3.0, "text": "World"},
+        ]
+        result = format_youtube_transcript_for_context(transcript)
+
+        assert "Hello" in result
+        assert "World" in result
+        assert "[00:01]" not in result
+        assert "[00:02]" not in result
+
+
+class TestFetchYouTubeTranscript:
+    @patch("api.utils.youtube_transcript.YouTubeTranscriptApi")
+    def test_successful_fetch(self, mock_yta):
+        mock_transcript_list = MagicMock()
+        mock_transcript = MagicMock()
+        mock_transcript.fetch.return_value = [
+            {"start": 0.0, "text": "Hello world"},
+            {"start": 5.0, "text": "Test transcript"},
+        ]
+        mock_transcript_list.find_transcript.return_value = mock_transcript
+        mock_yta.list_transcripts.return_value = mock_transcript_list
+
+        transcript, error = fetch_youtube_transcript("dQw4w9WgXcQ")
+
+        assert transcript is not None
+        assert len(transcript) == 2
+        assert error is None
+        mock_yta.list_transcripts.assert_called_once_with("dQw4w9WgXcQ")
+
+    @patch("api.utils.youtube_transcript.YouTubeTranscriptApi")
+    def test_no_transcript_found(self, mock_yta):
+        from youtube_transcript_api._errors import NoTranscriptFound
+
+        mock_yta.list_transcripts.side_effect = NoTranscriptFound(
+            "No transcript available"
+        )
+
+        transcript, error = fetch_youtube_transcript("dQw4w9WgXcQ")
+
+        assert transcript is None
+        assert error == "no transcript found"
+
+    @patch("api.utils.youtube_transcript.YouTubeTranscriptApi")
+    def test_video_unavailable(self, mock_yta):
+        from youtube_transcript_api._errors import VideoUnavailable
+
+        mock_yta.list_transcripts.side_effect = VideoUnavailable("Video not found")
+
+        transcript, error = fetch_youtube_transcript("invalid_video_id")
+
+        assert transcript is None
+        assert error == "video unavailable"
+
+
+class TestGetYouTubeTranscriptContext:
+    @patch("api.utils.youtube_transcript.fetch_youtube_transcript")
+    def test_returns_formatted_context(self, mock_fetch):
+        mock_fetch.return_value = (
+            [
+                {"start": 0.0, "text": "Hello world"},
+                {"start": 5.0, "text": "This is a test"},
+            ],
+            None,
+        )
+
+        result = get_youtube_transcript_context("dQw4w9WgXcQ")
+
+        assert "TRANSCRIPCION DEL VIDEO:" in result
+        assert "[00:00] Hello world" in result
+        assert "[00:05] This is a test" in result
+
+    @patch("api.utils.youtube_transcript.fetch_youtube_transcript")
+    def test_returns_empty_on_error(self, mock_fetch):
+        mock_fetch.return_value = (None, "no transcript found")
+
+        result = get_youtube_transcript_context("dQw4w9WgXcQ")
+
+        assert result == ""
+
+    @patch("api.utils.youtube_transcript.fetch_youtube_transcript")
+    def test_returns_empty_on_empty_transcript(self, mock_fetch):
+        mock_fetch.return_value = ([], None)
+
+        result = get_youtube_transcript_context("dQw4w9WgXcQ")
+
+        assert result == ""


### PR DESCRIPTION
## Summary
- Add YouTube transcript extraction when bot receives messages with YouTube links
- Fetch captions using `youtube-transcript-api` and include in AI context
- Bot only fetches transcripts when it decides to respond (not for all messages)

## Changes
- **api/utils/youtube_transcript.py**: New module with video ID extraction, transcript fetching, and formatting
- **api/index.py**: Modified `build_message_links_context()` to detect YouTube URLs and fetch transcripts
- **requirements.txt**: Added `youtube-transcript-api>=0.2.2`
- **tests/test_youtube_transcript.py**: Unit tests for new utilities

## Behavior
- When a user sends a YouTube link with text (question/comment)
- Bot decides to respond based on existing rules
- Transcript is fetched and appended to AI context as `TRANSCRIPCION DEL VIDEO:`
- AI receives full video transcript for answering questions about the video

## Example Output
```
LINKS DEL MENSAJE:
1. https://youtube.com/watch?v=abc123
  titulo: Video Title
  descripcion: Description

TRANSCRIPCION DEL VIDEO:
[00:00] First segment text...
[00:15] Second segment text...
```