### PR TITLE
Improve free AI message limit controls

### DIFF
--- a/api/chat_config_defaults.py
+++ b/api/chat_config_defaults.py
@@ -10,7 +10,7 @@ CHAT_CONFIG_DEFAULTS: Dict[str, object] = {
     "ai_command_followups": True,
     "ignore_link_fix_followups": True,
     "timezone_offset": -3,
-    "creditless_user_hourly_limit": 2,
+    "creditless_user_hourly_limit": 5,
 }
 
 TIMEZONE_OFFSET_MIN = -12

--- a/api/chat_settings.py
+++ b/api/chat_settings.py
@@ -129,7 +129,7 @@ def parse_chat_config(config: Mapping[str, Any]) -> ChatConfigData:
         creditless_limit=int(
             config.get(
                 "creditless_user_hourly_limit",
-                config.get("creditless_user_daily_limit", 2),
+                config.get("creditless_user_daily_limit", 5),
             )
         ),
     )
@@ -213,9 +213,12 @@ def build_config_keyboard(
         prefix = "✅" if enabled else "▫️"
         return {"text": f"{prefix} {label}", "callback_data": f"cfg:{action}:toggle"}
 
-    def creditless_button(label: str, value: int) -> Dict[str, str]:
-        prefix = "✅ " if value == parsed.creditless_limit else ""
-        return {"text": f"{prefix}{label}", "callback_data": f"cfg:creditless:{value}"}
+    def creditless_button(label: str, value: str) -> Dict[str, str]:
+        return {"text": label, "callback_data": f"cfg:creditless:{value}"}
+
+    creditless_current_label = (
+        "∞" if parsed.creditless_limit < 0 else str(parsed.creditless_limit)
+    )
 
     dec_offset = max(parsed.timezone_offset - 1, TIMEZONE_OFFSET_MIN)
     inc_offset = min(parsed.timezone_offset + 1, TIMEZONE_OFFSET_MAX)
@@ -261,11 +264,11 @@ def build_config_keyboard(
                     )
                 ],
                 [
-                    creditless_button("ninguno", 0),
-                    creditless_button("1", 1),
-                    creditless_button("2", 2),
-                    creditless_button("5", 5),
-                    creditless_button("∞", -1),
+                    creditless_button("0", "none"),
+                    creditless_button("-", "decrease"),
+                    creditless_button(creditless_current_label, "current"),
+                    creditless_button("+", "increase"),
+                    creditless_button("∞", "unlimited"),
                 ],
             ]
         )

--- a/api/index.py
+++ b/api/index.py
@@ -1490,9 +1490,7 @@ def get_prices(msg_text: str) -> Optional[str]:
         ).rstrip(".")
         percentage = f"{coin['quote'][convert_to_parameter].get(cmc_change_field, 0):+.2f}".rstrip(
             "0"
-        ).rstrip(
-            "."
-        )
+        ).rstrip(".")
         line = f"{ticker}: {price} {convert_to} ({percentage}% {tf_label})"
 
         if (
@@ -5668,9 +5666,30 @@ def handle_callback_query(callback_query: Dict[str, Any]) -> None:
                 pass
     elif action == "creditless":
         try:
-            limit = int(value)
-            if limit < -1:
-                raise ValueError
+            current_limit = int(
+                config.get(
+                    "creditless_user_hourly_limit",
+                    config.get("creditless_user_daily_limit", 5),
+                )
+            )
+            if value == "none":
+                limit = 0
+            elif value == "decrease":
+                limit = (
+                    current_limit if current_limit < 0 else max(0, current_limit - 1)
+                )
+            elif value == "current":
+                if callback_id:
+                    _answer_callback_query(callback_id)
+                return
+            elif value == "increase":
+                limit = current_limit if current_limit < 0 else current_limit + 1
+            elif value == "unlimited":
+                limit = -1
+            else:
+                limit = int(value)
+                if limit < -1:
+                    raise ValueError
             config = set_chat_config(
                 redis_client,
                 chat_id_str,

--- a/tests/test_chat_settings.py
+++ b/tests/test_chat_settings.py
@@ -91,6 +91,7 @@ def test_build_config_text_clarifies_group_free_ai_limit_is_messages():
     assert "a veces respondo solo en el grupo aunque nadie me llame" in text
     assert "6. mensajes gratis por usuario por hora" in text
     assert "cuantos mensajes de ia paga el grupo por usuario cada hora" in text
+    assert "\n5\n" in text
     assert "tocá los botones de abajo para cambiar la config" in text
 
 
@@ -443,6 +444,14 @@ def test_build_config_text_and_keyboard_reflect_values():
         == "✅ ignorar replies a links arreglados"
     )
     assert keyboard["inline_keyboard"][4][0]["callback_data"] == "cfg:random:toggle"
+    assert keyboard["inline_keyboard"][5][0]["text"] == "0"
+    assert keyboard["inline_keyboard"][5][1]["text"] == "-"
+    assert keyboard["inline_keyboard"][5][2]["text"] == "5"
+    assert (
+        keyboard["inline_keyboard"][5][2]["callback_data"] == "cfg:creditless:current"
+    )
+    assert keyboard["inline_keyboard"][5][3]["text"] == "+"
+    assert keyboard["inline_keyboard"][5][4]["text"] == "∞"
 
 
 def test_handle_config_command_loads_config():
@@ -739,6 +748,27 @@ class TestTimezoneConfig:
         utc3_btn = next(b for b in tz_row if "UTC-3" in b["text"])
         assert "🌍" in utc3_btn["text"]
 
+    def test_config_keyboard_creditless_stepper_uses_default_five(self):
+        from api.chat_settings import build_config_keyboard, CHAT_CONFIG_DEFAULTS
+
+        keyboard = build_config_keyboard(dict(CHAT_CONFIG_DEFAULTS))
+        creditless_row = keyboard["inline_keyboard"][5]
+
+        assert [button["text"] for button in creditless_row] == [
+            "0",
+            "-",
+            "5",
+            "+",
+            "∞",
+        ]
+        assert [button["callback_data"] for button in creditless_row] == [
+            "cfg:creditless:none",
+            "cfg:creditless:decrease",
+            "cfg:creditless:current",
+            "cfg:creditless:increase",
+            "cfg:creditless:unlimited",
+        ]
+
     def test_handle_callback_query_updates_timezone(self):
         from api.index import handle_callback_query
 
@@ -783,12 +813,12 @@ class TestTimezoneConfig:
         assert call_kwargs.get("timezone_offset") == -5
 
 
-def test_handle_callback_query_allows_unlimited_creditless_setting():
+def test_handle_callback_query_sets_creditless_unlimited():
     from api.index import handle_callback_query
 
     callback = {
         "id": "cbq",
-        "data": "cfg:creditless:-1",
+        "data": "cfg:creditless:unlimited",
         "message": {"chat": {"id": 1}, "message_id": 99},
     }
     with (
@@ -800,7 +830,7 @@ def test_handle_callback_query_allows_unlimited_creditless_setting():
                 "ai_random_replies": True,
                 "ai_command_followups": True,
                 "ignore_link_fix_followups": True,
-                "creditless_user_hourly_limit": 2,
+                "creditless_user_hourly_limit": 5,
             },
         ),
         patch(
@@ -823,3 +853,83 @@ def test_handle_callback_query_allows_unlimited_creditless_setting():
     mock_set.assert_called_once()
     call_kwargs = mock_set.call_args.kwargs
     assert call_kwargs.get("creditless_user_hourly_limit") == -1
+
+
+def test_handle_callback_query_increases_creditless_limit():
+    from api.index import handle_callback_query
+
+    callback = {
+        "id": "cbq",
+        "data": "cfg:creditless:increase",
+        "message": {"chat": {"id": 1}, "message_id": 99},
+    }
+    with (
+        patch("api.index.config_redis"),
+        patch(
+            "api.index.get_chat_config",
+            return_value={
+                "link_mode": "reply",
+                "ai_random_replies": True,
+                "ai_command_followups": True,
+                "ignore_link_fix_followups": True,
+                "creditless_user_hourly_limit": 5,
+            },
+        ),
+        patch(
+            "api.index.set_chat_config",
+            return_value={
+                "link_mode": "reply",
+                "ai_random_replies": True,
+                "ai_command_followups": True,
+                "ignore_link_fix_followups": True,
+                "creditless_user_hourly_limit": 6,
+            },
+        ) as mock_set,
+        patch("api.index.build_config_text", return_value="text"),
+        patch("api.index.build_config_keyboard", return_value={"inline_keyboard": []}),
+        patch("api.index.edit_message", return_value=True),
+        patch("api.index._answer_callback_query"),
+    ):
+        handle_callback_query(callback)
+
+    assert mock_set.call_args.kwargs["creditless_user_hourly_limit"] == 6
+
+
+def test_handle_callback_query_decrease_clamps_creditless_limit_at_zero():
+    from api.index import handle_callback_query
+
+    callback = {
+        "id": "cbq",
+        "data": "cfg:creditless:decrease",
+        "message": {"chat": {"id": 1}, "message_id": 99},
+    }
+    with (
+        patch("api.index.config_redis"),
+        patch(
+            "api.index.get_chat_config",
+            return_value={
+                "link_mode": "reply",
+                "ai_random_replies": True,
+                "ai_command_followups": True,
+                "ignore_link_fix_followups": True,
+                "creditless_user_hourly_limit": 0,
+            },
+        ),
+        patch(
+            "api.index.set_chat_config",
+            return_value={
+                "link_mode": "reply",
+                "ai_random_replies": True,
+                "ai_command_followups": True,
+                "ignore_link_fix_followups": True,
+                "creditless_user_hourly_limit": 0,
+            },
+        ) as mock_set,
+        patch("api.index.build_config_text", return_value="text"),
+        patch("api.index.build_config_keyboard", return_value={"inline_keyboard": []}),
+        patch("api.index.edit_message", return_value=True),
+        patch("api.index._answer_callback_query"),
+    ):
+        handle_callback_query(callback)
+
+    assert mock_set.call_args.kwargs["creditless_user_hourly_limit"] == 0


### PR DESCRIPTION
## Summary
- change the default group free AI message limit from 2 to 5 per user per hour
- replace fixed creditless presets in `/config` with `0`, `-`, current value, `+`, and `∞` controls
- add callback and rendering tests for the new creditless limit behavior

## Testing
- pytest tests/test_chat_settings.py -q