### PR TITLE
Skip image context injection when image bytes are missing

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -2567,10 +2567,13 @@ def _build_ai_request(
 
 def _inject_image_context(
     messages: List[Dict[str, Any]],
-    image_data: bytes,
+    image_data: Optional[bytes],
     image_file_id: Optional[str],
     response_meta: Optional[Dict[str, Any]],
 ) -> None:
+    if image_data is None:
+        return
+
     print("Processing image with vision model...")
 
     user_text = (
@@ -2620,7 +2623,8 @@ def ask_ai(
             enable_web_search=enable_web_search,
         )
 
-        _inject_image_context(messages, image_data, image_file_id, response_meta)
+        if image_data is not None:
+            _inject_image_context(messages, image_data, image_file_id, response_meta)
 
         response = complete_with_providers(
             system_message,

--- a/tests/test_ai_pipeline.py
+++ b/tests/test_ai_pipeline.py
@@ -744,6 +744,35 @@ def test_ask_ai_with_image():
         assert len(result) > 0
 
 
+def test_ask_ai_skips_image_injection_when_image_data_is_none(monkeypatch):
+    from api.index import ask_ai
+
+    monkeypatch.setattr("api.index.get_market_context", lambda: {})
+    monkeypatch.setattr("api.index.get_weather_context", lambda: {})
+    monkeypatch.setattr("api.index.get_time_context", lambda: {"formatted": "Friday"})
+    monkeypatch.setattr("api.index.get_hacker_news_context", lambda: [])
+    monkeypatch.setattr(
+        "api.index.build_system_message",
+        lambda _context_data, **_kw: {"role": "system", "content": "sys"},
+    )
+
+    inject_calls = []
+
+    def fake_inject_image_context(messages, image_data, image_file_id, response_meta):
+        inject_calls.append((messages, image_data, image_file_id, response_meta))
+
+    monkeypatch.setattr("api.index._inject_image_context", fake_inject_image_context)
+    monkeypatch.setattr(
+        "api.index.complete_with_providers",
+        lambda *_args, **_kwargs: "ok",
+    )
+
+    result = ask_ai([{"role": "user", "content": "hola"}], image_data=None)
+
+    assert result == "ok"
+    assert inject_calls == []
+
+
 def test_ask_ai_does_not_force_search_for_news_queries():
     from api.index import ask_ai
 


### PR DESCRIPTION
### Motivation
- Prevent a runtime `TypeError: a bytes-like object is required, not 'NoneType'` that occurred when image-related code attempted to base64-encode a `None` payload. 
- Keep text-only AI requests out of the vision pipeline so they run without unnecessary work or crashes.

### Description
- Change `_inject_image_context` signature to accept `Optional[bytes]` and return early when `image_data` is `None` to avoid calling `base64.b64encode(None)` in the image pipeline. 
- Update `ask_ai` to only call `_inject_image_context` when `image_data` is present. 
- Add `test_ask_ai_skips_image_injection_when_image_data_is_none` to verify `ask_ai(..., image_data=None)` does not invoke image injection and still returns the provider response. 

### Testing
- Ran targeted tests with `pytest -q tests/test_ai_pipeline.py -k 'skips_image_injection_when_image_data_is_none or ask_ai_with_image'` which passed (`2 passed, 47 deselected`).
- Ran linter with `ruff check .` which passed (`All checks passed!`).
- Ran full test suite with `pytest -q` which passed (`652 passed`).
- Ran `ruff format --check .` which reported repository-wide formatting drift unrelated to this change (not introduced here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4cc4dae0832caa70ce2aa074109a)