### PR TITLE
feat: group Polymarket World Cup matches by date

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1438,7 +1438,7 @@ def get_polymarket_world_cup_games() -> str:
         try:
             kickoff_utc = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
             kickoff_ba = kickoff_utc.astimezone(BA_TZ)
-            date_str = kickoff_ba.strftime("%Y-%m-%d")
+            date_str = kickoff_ba.strftime("%a, %B %d").replace(" 0", " ")
             time_str = kickoff_ba.strftime("%H:%M UTC-3")
         except ValueError:
             if end_date:

--- a/api/index.py
+++ b/api/index.py
@@ -1402,6 +1402,7 @@ def get_polymarket_world_cup_games() -> str:
                 ]
             )
 
+    games_by_date: Dict[str, List[Tuple[str, str]]] = {}
     for event in games[:POLYMARKET_WORLD_CUP_LIMIT]:
         title = event.get("title")
         slug = event.get("slug")
@@ -1432,16 +1433,38 @@ def get_polymarket_world_cup_games() -> str:
             f'<a href="{escape(event_url, quote=True)}">'
             f"{escape(display_title)}</a>"
         )
-        lines.extend(["", linked_title])
 
         end_date = str(event.get("endDate") or "")
         try:
             kickoff_utc = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
             kickoff_ba = kickoff_utc.astimezone(BA_TZ)
-            lines.append(kickoff_ba.strftime("%Y-%m-%d %H:%M UTC-3"))
+            date_str = kickoff_ba.strftime("%Y-%m-%d")
+            time_str = kickoff_ba.strftime("%H:%M UTC-3")
         except ValueError:
             if end_date:
-                lines.append(end_date[:16].replace("T", " "))
+                date_str = end_date[:10]
+                time_str = end_date[11:16].replace("T", " ")
+            else:
+                date_str = "Unknown Date"
+                time_str = ""
+
+        if date_str not in games_by_date:
+            games_by_date[date_str] = []
+        games_by_date[date_str].append((linked_title, time_str))
+
+    for date_str, daily_games in games_by_date.items():
+        if date_str != "Unknown Date":
+            lines.extend(["", date_str])
+        else:
+            lines.append("")
+        for linked_title, time_str in daily_games:
+            lines.append(linked_title)
+            if time_str:
+                lines.append(time_str)
+            lines.append("")
+
+    if lines and not lines[-1]:
+        lines.pop()
 
     if len(lines) == 1:
         return "Could not fetch World Cup games from Polymarket"

--- a/tests/test_polymarket_world_cup.py
+++ b/tests/test_polymarket_world_cup.py
@@ -104,7 +104,7 @@ def test_get_polymarket_world_cup_games_filters_props_and_formats_kickoff(
     assert "Exact Score" not in result
     assert "[🇲🇽 Mexico 69.5%] vs. 🇿🇦 South Africa 10.5%" in result
     assert "Draw 20.5%" not in result
-    assert "2026-06-11\n<a href=" in result
+    assert "Thu, June 11\n<a href=" in result
     assert "16:00 UTC-3\n\n<a href=" in result
     assert (
         '<a href="https://polymarket.com/sports/world-cup/'

--- a/tests/test_polymarket_world_cup.py
+++ b/tests/test_polymarket_world_cup.py
@@ -104,7 +104,8 @@ def test_get_polymarket_world_cup_games_filters_props_and_formats_kickoff(
     assert "Exact Score" not in result
     assert "[🇲🇽 Mexico 69.5%] vs. 🇿🇦 South Africa 10.5%" in result
     assert "Draw 20.5%" not in result
-    assert "2026-06-11 16:00 UTC-3" in result
+    assert "2026-06-11\n<a href=" in result
+    assert "16:00 UTC-3\n\n<a href=" in result
     assert (
         '<a href="https://polymarket.com/sports/world-cup/'
         'fifwc-mex-rsa-2026-06-11">[🇲🇽 Mexico 69.5%] vs. '


### PR DESCRIPTION
Groups Polymarket World Cup matches by date in `/mundial` command, updating the view to show a date header, the matches beneath it, and just the time for the match. Updates tests appropriately to match the new output.

---
*PR created automatically by Jules for task [10121658393330070792](https://jules.google.com/task/10121658393330070792) started by @astrovm*