### PR TITLE
fix(bot): fix _handle_tasks_command signature positional argument

### DIFF
--- a/api/bot/message_handler.py
+++ b/api/bot/message_handler.py
@@ -1385,11 +1385,11 @@ def _handle_gif_command(
 
 
 def _handle_tasks_command(
+    deps: Any = None,
     *,
     command: str,
     chat_id: str,
     handler_func: Callable[..., str | Tuple[str, Optional[Dict[str, Any]]]],
-    deps: Any = None,
     message: Any = None,
     billing_helper: Any = None,
     redis_client: Any = None,

--- a/tests/test_message_routing.py
+++ b/tests/test_message_routing.py
@@ -341,6 +341,49 @@ def test_handle_non_ai_command_passes_world_cup_country_query():
     handler.assert_called_once_with(timezone_offset=-3, team_query="argentina")
 
 
+def test_handle_non_ai_command_tasks_command():
+    from api.bot.message_handler import (
+        CommandDispatchContext,
+        PreparedMessage,
+        _handle_non_ai_command,
+    )
+
+    handler = MagicMock(return_value=("lista de tareas", {"inline_keyboard": []}))
+    commands = {
+        "/tasks": (handler, False, False),
+        "/tareas": (handler, False, False),
+    }
+
+    deps = MagicMock()
+    for cmd in ("/tasks", "/tareas"):
+        response = _handle_non_ai_command(
+            deps,
+            CommandDispatchContext(
+                commands=commands,
+                command=cmd,
+                sanitized_message_text="",
+                message={"message_id": "10"},
+                chat_id="123",
+                chat_type="private",
+                user_id=7,
+                numeric_chat_id=123,
+                prepared_message=PreparedMessage(
+                    message_text=cmd,
+                    photo_file_id=None,
+                    audio_file_id=None,
+                ),
+                billing_helper=MagicMock(),
+                reply_context_text=None,
+                user_identity="Ana (ana)",
+                redis_client=MagicMock(),
+                timezone_offset=-3,
+            ),
+        )
+
+        assert response == ("lista de tareas", {"inline_keyboard": []}, False, cmd)
+        handler.assert_called_with("123")
+
+
 def test_message_handler_routes_ai_command_through_known_command_path(monkeypatch):
     from api.bot.message_handler import handle_msg
 


### PR DESCRIPTION
## Summary
Fixes a `TypeError` when executing `/tasks` or `/tareas`:
`_handle_tasks_command() takes 0 positional arguments but 1 positional argument (and 7 keyword-only arguments) were given`

## Cause
`_handle_non_ai_command` dispatches special handlers by calling `special_handler(deps, command=command, ...)` with `deps` as a positional argument. `_handle_tasks_command` had `*` at the start of its parameter list instead of after `deps`, causing it to accept zero positional arguments.

## Solution
- Moved `deps: Any = None` to the first positional argument of `_handle_tasks_command`.
- Added unit test in `tests/test_message_routing.py` covering non-AI command dispatching for `/tasks` and `/tareas`.