### PR TITLE
Reserve AI credits before expensive work

### DIFF
--- a/api/ai/pricing.py
+++ b/api/ai/pricing.py
@@ -19,6 +19,7 @@ CHAT_OUTPUT_TOKEN_LIMIT = 1024
 REASONING_CHAT_OUTPUT_TOKEN_LIMIT = 8192
 VISION_OUTPUT_TOKEN_LIMIT = 512
 IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE = 1_200
+SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE = 4_000
 WEB_SEARCH_USD_MICROS_PER_REQUEST = 1_660
 
 
@@ -159,6 +160,7 @@ def estimate_vision_reserve_credits(
     *,
     prompt_text: str,
     image_data: Optional[bytes] = None,
+    extra_input_tokens: int = 0,
     max_output_tokens: int = VISION_OUTPUT_TOKEN_LIMIT,
     model: str = "google/gemini-3.1-flash-lite-preview",
 ) -> int:
@@ -176,7 +178,7 @@ def estimate_vision_reserve_credits(
             ],
         }
     ]
-    input_tokens = estimate_message_tokens(input_payload)
+    input_tokens = estimate_message_tokens(input_payload) + extra_input_tokens
     usd_micros = (
         input_tokens * pricing["input_per_million"]
         + max_output_tokens * pricing["output_per_million"]

--- a/api/ai/service.py
+++ b/api/ai/service.py
@@ -42,6 +42,100 @@ class AIService:
     estimate_image_context_reserve_credits: Callable[[bytes, str], int]
     stream_summary_command: Callable[[str, Any, str], Any]
 
+    @staticmethod
+    def _refund_if_present(
+        request: AIConversationRequest,
+        reservation: Optional[Dict[str, Any]],
+        *,
+        reason: str,
+    ) -> None:
+        if reservation:
+            request.billing_helper.refund_reserved_ai_credits(
+                reservation, reason=reason
+            )
+
+    def _prepare_conversation_messages(
+        self, request: AIConversationRequest
+    ) -> Tuple[List[Dict[str, Any]], int]:
+        chat_history = self.get_chat_history(request.chat_id, request.redis_client)
+        reply_to_message = (
+            request.message.get("reply_to_message") if request.message else None
+        )
+        reply_to_message_id = None
+        if isinstance(reply_to_message, dict):
+            raw_reply_to_id = reply_to_message.get("message_id")
+            if raw_reply_to_id is not None:
+                reply_to_message_id = str(raw_reply_to_id)
+        visible_history, summary_text, retrieved_messages, summary_cost = (
+            self.prepare_chat_memory(
+                request.redis_client,
+                request.chat_id,
+                chat_history,
+                request.prompt_text,
+                reply_to_message_id=reply_to_message_id,
+                compaction_threshold=request.compaction_threshold,
+                compaction_keep=request.compaction_keep,
+            )
+        )
+        messages = self.build_ai_messages(
+            request.message,
+            visible_history,
+            request.prompt_text,
+            request.reply_context_text,
+            summary_text=summary_text,
+            retrieved_messages=retrieved_messages,
+            timezone_offset=request.timezone_offset,
+        )
+        return messages, summary_cost
+
+    def _reserve_image_context(
+        self,
+        request: AIConversationRequest,
+        base_charge_meta: Dict[str, Any],
+        existing_charge_meta: Optional[Dict[str, Any]],
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Tuple[str, bool]]]:
+        if (
+            existing_charge_meta
+            or not request.prepared_message.resized_image_data
+            or not request.prepared_message.photo_file_id
+        ):
+            return existing_charge_meta, None
+
+        if (
+            not self.check_provider_available(scope="vision")
+            and not self.has_openrouter_fallback()
+        ):
+            request.billing_helper.refund_reserved_ai_credits(
+                base_charge_meta, reason="image_context_local_rate_limit"
+            )
+            rate_limit_msg = self.handle_rate_limit(
+                request.chat_id, request.message
+            )
+            response = "ok" if request.is_spontaneous else rate_limit_msg
+            return None, (response, False)
+
+        image_prompt = "Describe what you see in this image in detail."
+        media_charge_meta, media_charge_error = (
+            request.billing_helper.reserve_ai_credits(
+                "image_context_media",
+                self.estimate_image_context_reserve_credits(
+                    request.prepared_message.resized_image_data,
+                    image_prompt,
+                ),
+                metadata={
+                    "photo_file_id": request.prepared_message.photo_file_id
+                },
+            )
+        )
+        if not media_charge_error:
+            return media_charge_meta, None
+
+        request.billing_helper.refund_reserved_ai_credits(
+            base_charge_meta, reason="image_context_reserve_failed"
+        )
+        response = "ok" if request.is_spontaneous else media_charge_error
+        return None, (response, False)
+
     def run_conversation(
         self,
         request: AIConversationRequest,
@@ -53,100 +147,68 @@ class AIService:
             )
             return ("ok", False) if request.is_spontaneous else billing_unavailable
 
-        chat_history = self.get_chat_history(request.chat_id, request.redis_client)
-        reply_to_message = request.message.get("reply_to_message") if request.message else None
-        reply_to_message_id = None
-        if isinstance(reply_to_message, dict):
-            raw_reply_to_id = reply_to_message.get("message_id")
-            if raw_reply_to_id is not None:
-                reply_to_message_id = str(raw_reply_to_id)
-        visible_history, summary_text, retrieved_messages, summary_cost = self.prepare_chat_memory(
-            request.redis_client,
-            request.chat_id,
-            chat_history,
-            request.prompt_text,
-            reply_to_message_id=reply_to_message_id,
-            compaction_threshold=request.compaction_threshold,
-            compaction_keep=request.compaction_keep,
+        admission_messages = [{"role": "user", "content": request.prompt_text}]
+        media_charge_meta: Optional[Dict[str, Any]] = (
+            dict(request.prepared_message.image_charge_meta)
+            if getattr(request.prepared_message, "image_charge_meta", None)
+            else None
         )
-        ai_messages = self.build_ai_messages(
-            request.message,
-            visible_history,
-            request.prompt_text,
-            request.reply_context_text,
-            summary_text=summary_text,
-            retrieved_messages=retrieved_messages,
-            timezone_offset=request.timezone_offset,
-        )
-
         main_reserve_credits, reserve_meta = self.estimate_ai_base_reserve_credits(
-            ai_messages,
+            admission_messages,
             extra_input_tokens=(
                 IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE
-                if request.prepared_message.resized_image_data
-                and request.prepared_message.photo_file_id
+                if request.prepared_message.photo_file_id
                 else 0
             ),
             timezone_offset=request.timezone_offset,
         )
-        if (
-            not self.check_provider_available(scope="chat")
-            and not self.has_openrouter_fallback()
-        ):
-            rate_limit_msg = self.handle_rate_limit(request.chat_id, request.message)
-            return ("ok", False) if request.is_spontaneous else (rate_limit_msg, False)
         base_charge_meta, base_charge_error = request.billing_helper.reserve_ai_credits(
             "ai_response_base",
             main_reserve_credits,
             metadata={
-                "estimated_prompt_messages": len(ai_messages),
-                "summary_cost": summary_cost,
+                "estimated_prompt_messages": len(admission_messages),
                 **reserve_meta,
             },
         )
         if base_charge_error:
+            self._refund_if_present(
+                request,
+                media_charge_meta,
+                reason="ai_response_base_reserve_failed",
+            )
             return (
                 ("ok", False) if request.is_spontaneous else (base_charge_error, False)
             )
 
-        media_charge_meta: Optional[Dict[str, Any]] = None
         if (
-            request.prepared_message.resized_image_data
-            and request.prepared_message.photo_file_id
+            not self.check_provider_available(scope="chat")
+            and not self.has_openrouter_fallback()
         ):
-            image_prompt = "Describe what you see in this image in detail."
-            if (
-                not self.check_provider_available(scope="vision")
-                and not self.has_openrouter_fallback()
-            ):
-                request.billing_helper.refund_reserved_ai_credits(
-                    base_charge_meta, reason="image_context_local_rate_limit"
-                )
-                rate_limit_msg = self.handle_rate_limit(
-                    request.chat_id, request.message
-                )
-                return (
-                    ("ok", False) if request.is_spontaneous else (rate_limit_msg, False)
-                )
-            media_charge_meta, media_charge_error = (
-                request.billing_helper.reserve_ai_credits(
-                    "image_context_media",
-                    self.estimate_image_context_reserve_credits(
-                        request.prepared_message.resized_image_data,
-                        image_prompt,
-                    ),
-                    metadata={"photo_file_id": request.prepared_message.photo_file_id},
-                )
+            request.billing_helper.refund_reserved_ai_credits(
+                base_charge_meta, reason="chat_provider_unavailable"
             )
-            if media_charge_error:
-                request.billing_helper.refund_reserved_ai_credits(
-                    base_charge_meta, reason="image_context_reserve_failed"
-                )
-                return (
-                    ("ok", False)
-                    if request.is_spontaneous
-                    else (media_charge_error, False)
-                )
+            self._refund_if_present(
+                request, media_charge_meta, reason="chat_provider_unavailable"
+            )
+            rate_limit_msg = self.handle_rate_limit(request.chat_id, request.message)
+            return ("ok", False) if request.is_spontaneous else (rate_limit_msg, False)
+
+        try:
+            ai_messages, summary_cost = self._prepare_conversation_messages(request)
+        except Exception:
+            request.billing_helper.refund_reserved_ai_credits(
+                base_charge_meta, reason="ai_request_preparation_failed"
+            )
+            self._refund_if_present(
+                request, media_charge_meta, reason="ai_request_preparation_failed"
+            )
+            raise
+
+        media_charge_meta, image_error = self._reserve_image_context(
+            request, base_charge_meta, media_charge_meta
+        )
+        if image_error:
+            return image_error
 
         ai_response_meta: Dict[str, Any] = {}
         response_msg = self.handle_ai_response(
@@ -201,18 +263,6 @@ class AIService:
         if not self.credits_db_service.is_configured():
             return self.handle_rate_limit(request.chat_id, request.message), None, True
 
-        if (
-            not self.check_provider_available(scope="chat")
-            and not self.has_openrouter_fallback()
-        ):
-            return self.handle_rate_limit(request.chat_id, request.message), None, True
-
-        token_iterator, pending_marker = self.stream_summary_command(
-            request.chat_id,
-            request.redis_client,
-            request.prompt_text,
-        )
-
         main_reserve_credits, reserve_meta = self.estimate_ai_base_reserve_credits(
             [{"role": "user", "content": "summary"}],
             extra_input_tokens=0,
@@ -224,6 +274,31 @@ class AIService:
         )
         if base_charge_error:
             return base_charge_error, None, True
+
+        if (
+            not self.check_provider_available(scope="chat")
+            and not self.has_openrouter_fallback()
+        ):
+            request.billing_helper.refund_reserved_ai_credits(
+                base_charge_meta, reason="summary_provider_unavailable"
+            )
+            return self.handle_rate_limit(request.chat_id, request.message), None, True
+
+        try:
+            token_iterator, pending_marker = self.stream_summary_command(
+                request.chat_id,
+                request.redis_client,
+                request.prompt_text,
+            )
+        except Exception:
+            _summary_logger.exception(
+                "summary_stream: preparation failed for chat_id=%s",
+                request.chat_id,
+            )
+            request.billing_helper.refund_reserved_ai_credits(
+                base_charge_meta, reason="summary_preparation_failed"
+            )
+            return "no pude generar el resumen", None, True
 
         try:
             final_text = stream_consumer(token_iterator)

--- a/api/ai/service.py
+++ b/api/ai/service.py
@@ -136,6 +136,34 @@ class AIService:
         response = "ok" if request.is_spontaneous else media_charge_error
         return None, (response, False)
 
+    def _estimate_full_conversation_reserve(
+        self,
+        request: AIConversationRequest,
+        messages: List[Dict[str, Any]],
+        *,
+        summary_cost_usd_micros: int,
+    ) -> Tuple[int, Dict[str, Any]]:
+        full_reserve_credits, reserve_meta = (
+            self.estimate_ai_base_reserve_credits(
+                messages,
+                extra_input_tokens=(
+                    IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE
+                    if request.prepared_message.photo_file_id
+                    else 0
+                ),
+                timezone_offset=request.timezone_offset,
+            )
+        )
+        required_credits = full_reserve_credits + credit_units_from_usd_micros(
+            summary_cost_usd_micros
+        )
+        return required_credits, {
+            "estimated_prompt_messages": len(messages),
+            "required_reserve_credits": required_credits,
+            "summary_cost_usd_micros": summary_cost_usd_micros,
+            **reserve_meta,
+        }
+
     def run_conversation(
         self,
         request: AIConversationRequest,
@@ -204,6 +232,33 @@ class AIService:
             )
             raise
 
+        full_reserve_credits, full_reserve_meta = (
+            self._estimate_full_conversation_reserve(
+                request,
+                ai_messages,
+                summary_cost_usd_micros=summary_cost,
+            )
+        )
+        if full_reserve_credits > main_reserve_credits:
+            request.billing_helper.refund_reserved_ai_credits(
+                base_charge_meta, reason="ai_response_reserve_adjustment"
+            )
+            base_charge_meta, base_charge_error = (
+                request.billing_helper.reserve_ai_credits(
+                    "ai_response_base",
+                    full_reserve_credits,
+                    metadata=full_reserve_meta,
+                )
+            )
+            if base_charge_error:
+                self._refund_if_present(
+                    request,
+                    media_charge_meta,
+                    reason="ai_response_reserve_adjustment_failed",
+                )
+                response = "ok" if request.is_spontaneous else base_charge_error
+                return response, False
+
         media_charge_meta, image_error = self._reserve_image_context(
             request, base_charge_meta, media_charge_meta
         )
@@ -234,10 +289,9 @@ class AIService:
             billing_segments.insert(0, _make_summary_billing_segment(summary_cost))
         if bool(ai_response_meta.get("ai_fallback")):
             # The local fallback has no provider usage, so release every reserve.
-            if media_charge_meta:
-                request.billing_helper.refund_reserved_ai_credits(
-                    media_charge_meta, reason="ai_response_fallback"
-                )
+            self._refund_if_present(
+                request, media_charge_meta, reason="ai_response_fallback"
+            )
             request.billing_helper.refund_reserved_ai_credits(
                 base_charge_meta, reason="ai_response_fallback"
             )

--- a/api/bot/message_handler.py
+++ b/api/bot/message_handler.py
@@ -43,6 +43,7 @@ from api.bot.streaming import (
 
 CommandTuple = Tuple[Callable[..., Any], bool, bool]
 CommandResponse = Tuple[Optional[str], Optional[Dict[str, Any]], bool, Optional[str]]
+UNKNOWN_AUDIO_DURATION_ESTIMATE_SECONDS = 60.0
 
 
 def _reserve_media_credits(
@@ -54,16 +55,19 @@ def _reserve_media_credits(
     reason: str,
     metadata: Optional[Dict[str, Any]] = None,
 ) -> Tuple[Optional[Mapping[str, Any]], Optional[str]]:
-    if (
-        not deps.check_provider_available(scope=scope)
-        and not deps.has_openrouter_fallback()
-    ):
-        return None, "rate_limited"
     media_charge_meta, media_charge_error = billing_helper.reserve_ai_credits(
         reason, reserve_credits, metadata=metadata
     )
     if media_charge_error:
         return None, media_charge_error
+    if (
+        not deps.check_provider_available(scope=scope)
+        and not deps.has_openrouter_fallback()
+    ):
+        billing_helper.refund_reserved_ai_credits(
+            media_charge_meta, reason=f"{reason}_provider_unavailable"
+        )
+        return None, "rate_limited"
     return media_charge_meta, None
 
 
@@ -343,6 +347,7 @@ class PreparedMessage:
     resized_image_data: Optional[bytes] = None
     early_response: Optional[str] = None
     audio_duration_seconds: float = 0.0
+    image_charge_meta: Optional[Mapping[str, Any]] = None
 
 
 @dataclass(frozen=True)
@@ -820,25 +825,16 @@ def _process_audio_media(
     if not audio_file_id:
         return prepared
 
-    duration = _resolve_audio_duration_seconds(
-        message,
-        audio_file_id=audio_file_id,
-        deps=deps,
-    )
-    if duration is None:
-        return replace(
-            prepared,
-            audio_duration_seconds=0.0,
-            early_response="ok" if not prepared.message_text else None,
-        )
+    duration = _extract_audio_duration_seconds(message)
+    estimated_duration = duration or UNKNOWN_AUDIO_DURATION_ESTIMATE_SECONDS
 
     media_charge_meta, reserve_error = _reserve_media_credits(
         deps,
         billing_helper,
         "transcribe",
-        estimate_transcribe_reserve_credits(duration),
+        estimate_transcribe_reserve_credits(estimated_duration),
         reason="auto_audio_media",
-        metadata={"audio_seconds": duration},
+        metadata={"estimated_audio_seconds": estimated_duration},
     )
     if reserve_error == "rate_limited":
         chat_id = str(
@@ -855,6 +851,23 @@ def _process_audio_media(
             audio_duration_seconds=duration,
             early_response=reserve_error,
         )
+
+    if duration <= 0:
+        resolved_duration = _resolve_audio_duration_seconds(
+            message,
+            audio_file_id=audio_file_id,
+            deps=deps,
+        )
+        if resolved_duration is None:
+            billing_helper.refund_reserved_ai_credits(
+                media_charge_meta, reason="auto_audio_duration_unavailable"
+            )
+            return replace(
+                prepared,
+                audio_duration_seconds=0.0,
+                early_response="ok" if not prepared.message_text else None,
+            )
+        duration = resolved_duration
 
     transcription, error, billing_segment = deps._transcribe_audio_file(
         audio_file_id,
@@ -886,21 +899,62 @@ def _process_audio_media(
 def _process_photo_media(
     prepared: PreparedMessage,
     *,
+    message: Dict[str, Any],
     deps: MessageHandlerDeps,
+    billing_helper: AIMessageBilling,
 ) -> PreparedMessage:
     if not prepared.photo_file_id:
         return prepared
 
-    image_data = deps.download_telegram_file(prepared.photo_file_id)
-    if image_data:
+    image_prompt = "Describe what you see in this image in detail."
+    media_charge_meta, reserve_error = _reserve_media_credits(
+        deps,
+        billing_helper,
+        "vision",
+        deps.estimate_image_context_reserve_credits(b"", image_prompt),
+        reason="image_context_media",
+        metadata={"photo_file_id": prepared.photo_file_id},
+    )
+    if reserve_error == "rate_limited":
+        chat_id = str(
+            cast(Mapping[str, Any], message.get("chat") or {}).get("id") or ""
+        )
+        return replace(
+            prepared,
+            early_response=deps.handle_rate_limit(chat_id, message),
+        )
+    if reserve_error:
+        return replace(prepared, early_response=reserve_error)
+
+    try:
+        image_data = deps.download_telegram_file(prepared.photo_file_id)
+        resized_image = (
+            deps.resize_image_if_needed(image_data) if image_data else None
+        )
+    except Exception:
+        billing_helper.refund_reserved_ai_credits(
+            media_charge_meta, reason="image_context_preparation_failed"
+        )
+        raise
+
+    if resized_image:
         return replace(
             prepared,
             message_text=prepared.message_text or "que onda con esta foto",
-            resized_image_data=deps.resize_image_if_needed(image_data),
+            resized_image_data=resized_image,
+            image_charge_meta=media_charge_meta,
         )
+
+    billing_helper.refund_reserved_ai_credits(
+        media_charge_meta, reason="image_context_download_failed"
+    )
     if prepared.message_text:
         return prepared
-    return replace(prepared, message_text="no pude ver tu foto, boludo")
+    return replace(
+        prepared,
+        message_text="no pude ver tu foto, boludo",
+        early_response="no pude ver tu foto, boludo",
+    )
 
 
 def _process_message_media(
@@ -923,7 +977,12 @@ def _process_message_media(
     )
     if processed.early_response is not None:
         return processed
-    return _process_photo_media(processed, deps=deps)
+    return _process_photo_media(
+        processed,
+        message=message,
+        deps=deps,
+        billing_helper=billing_helper,
+    )
 
 
 def _extract_audio_duration_seconds(message: Mapping[str, Any]) -> float:
@@ -1284,67 +1343,32 @@ def _handle_transcribe_command(
 ) -> Tuple[Optional[str], Optional[Dict[str, Any]], bool, Optional[str]]:
     """Handle /transcribe command for audio and images."""
     reserve_credits = 0
+    reserve_scope = "vision"
     replied_message = cast(Mapping[str, Any], message.get("reply_to_message") or {})
     if replied_message.get("voice") or replied_message.get("audio"):
-        replied_audio_file_id = None
-        voice = replied_message.get("voice")
-        if isinstance(voice, Mapping):
-            replied_audio_file_id = str(voice.get("file_id") or "") or None
-        audio = replied_message.get("audio")
-        if not replied_audio_file_id and isinstance(audio, Mapping):
-            replied_audio_file_id = str(audio.get("file_id") or "") or None
-        audio_duration_seconds = _resolve_audio_duration_seconds(
-            message,
-            audio_file_id=replied_audio_file_id,
-            deps=deps,
+        reserve_scope = "transcribe"
+        audio_duration_seconds = (
+            _extract_audio_duration_seconds(message)
+            or UNKNOWN_AUDIO_DURATION_ESTIMATE_SECONDS
         )
-        if audio_duration_seconds is None:
-            return "ok", None, False, None
-        if (
-            not deps.check_provider_available(
-                scope="transcribe",
-            )
-            and not deps.has_openrouter_fallback()
-        ):
-            return deps.handle_rate_limit(chat_id, message), None, False, command
         reserve_credits = estimate_transcribe_reserve_credits(
             audio_duration_seconds
         )
     else:
-        replied_photo_file_id = deps.extract_message_content(message)[1]
-        replied_image_data = (
-            deps.download_telegram_file(replied_photo_file_id)
-            if replied_photo_file_id
-            else None
+        reserve_credits = deps.estimate_image_context_reserve_credits(
+            b"",
+            "Describe what you see in this image in detail.",
         )
-        if (
-            isinstance(replied_image_data, (bytes, bytearray))
-            and replied_image_data
-        ):
-            resized_image = deps.resize_image_if_needed(bytes(replied_image_data))
-            if (
-                not deps.check_provider_available(
-                    scope="vision",
-                )
-                and not deps.has_openrouter_fallback()
-            ):
-                return (
-                    deps.handle_rate_limit(chat_id, message),
-                    None,
-                    False,
-                    command,
-                )
-            reserve_credits = deps.estimate_image_context_reserve_credits(
-                resized_image,
-                "Describe what you see in this image in detail.",
-            )
-        else:
-            reserve_credits = 1
 
-    media_charge_meta, media_charge_error = billing_helper.reserve_ai_credits(
-        "transcribe_command_media",
+    media_charge_meta, media_charge_error = _reserve_media_credits(
+        deps,
+        billing_helper,
+        reserve_scope,
         reserve_credits,
+        reason="transcribe_command_media",
     )
+    if media_charge_error == "rate_limited":
+        return deps.handle_rate_limit(chat_id, message), None, False, command
     if media_charge_error:
         return media_charge_error, None, False, command
 

--- a/api/bot/message_handler.py
+++ b/api/bot/message_handler.py
@@ -43,7 +43,7 @@ from api.bot.streaming import (
 
 CommandTuple = Tuple[Callable[..., Any], bool, bool]
 CommandResponse = Tuple[Optional[str], Optional[Dict[str, Any]], bool, Optional[str]]
-UNKNOWN_AUDIO_DURATION_ESTIMATE_SECONDS = 60.0
+UNKNOWN_AUDIO_ADMISSION_SECONDS = 1.0
 
 
 def _reserve_media_credits(
@@ -71,6 +71,32 @@ def _reserve_media_credits(
     return media_charge_meta, None
 
 
+def _adjust_media_reservation(
+    deps: Any,
+    billing_helper: AIMessageBilling,
+    scope: str,
+    reservation: Optional[Mapping[str, Any]],
+    *,
+    reserved_credits: int,
+    required_credits: int,
+    reason: str,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[Mapping[str, Any]], Optional[str]]:
+    if required_credits <= reserved_credits:
+        return reservation, None
+    billing_helper.refund_reserved_ai_credits(
+        reservation, reason=f"{reason}_reserve_adjustment"
+    )
+    return _reserve_media_credits(
+        deps,
+        billing_helper,
+        scope,
+        required_credits,
+        reason=reason,
+        metadata=metadata,
+    )
+
+
 def _settle_media_result(
     billing_helper: AIMessageBilling,
     media_charge_meta: Optional[Mapping[str, Any]],
@@ -90,6 +116,28 @@ def _settle_media_result(
             list(billing_segments),
             reason=settle_reason,
         )
+
+
+def _media_reserve_error_response(
+    prepared: PreparedMessage,
+    *,
+    message: Mapping[str, Any],
+    deps: MessageHandlerDeps,
+    reserve_error: Optional[str],
+    audio_duration_seconds: float,
+) -> Optional[PreparedMessage]:
+    if not reserve_error:
+        return None
+    if reserve_error == "rate_limited":
+        chat_id = str(
+            cast(Mapping[str, Any], message.get("chat") or {}).get("id") or ""
+        )
+        reserve_error = deps.handle_rate_limit(chat_id, dict(message))
+    return replace(
+        prepared,
+        audio_duration_seconds=audio_duration_seconds,
+        early_response=reserve_error,
+    )
 
 
 @dataclass(frozen=True)
@@ -826,31 +874,26 @@ def _process_audio_media(
         return prepared
 
     duration = _extract_audio_duration_seconds(message)
-    estimated_duration = duration or UNKNOWN_AUDIO_DURATION_ESTIMATE_SECONDS
+    estimated_duration = duration or UNKNOWN_AUDIO_ADMISSION_SECONDS
+    reserved_credits = estimate_transcribe_reserve_credits(estimated_duration)
 
     media_charge_meta, reserve_error = _reserve_media_credits(
         deps,
         billing_helper,
         "transcribe",
-        estimate_transcribe_reserve_credits(estimated_duration),
+        reserved_credits,
         reason="auto_audio_media",
         metadata={"estimated_audio_seconds": estimated_duration},
     )
-    if reserve_error == "rate_limited":
-        chat_id = str(
-            cast(Mapping[str, Any], message.get("chat") or {}).get("id") or ""
-        )
-        return replace(
-            prepared,
-            audio_duration_seconds=duration,
-            early_response=deps.handle_rate_limit(chat_id, message),
-        )
-    if reserve_error:
-        return replace(
-            prepared,
-            audio_duration_seconds=duration,
-            early_response=reserve_error,
-        )
+    reserve_error_response = _media_reserve_error_response(
+        prepared,
+        message=message,
+        deps=deps,
+        reserve_error=reserve_error,
+        audio_duration_seconds=duration,
+    )
+    if reserve_error_response:
+        return reserve_error_response
 
     if duration <= 0:
         resolved_duration = _resolve_audio_duration_seconds(
@@ -868,6 +911,26 @@ def _process_audio_media(
                 early_response="ok" if not prepared.message_text else None,
             )
         duration = resolved_duration
+        required_credits = estimate_transcribe_reserve_credits(duration)
+        media_charge_meta, reserve_error = _adjust_media_reservation(
+            deps,
+            billing_helper,
+            "transcribe",
+            media_charge_meta,
+            reserved_credits=reserved_credits,
+            required_credits=required_credits,
+            reason="auto_audio_media",
+            metadata={"estimated_audio_seconds": duration},
+        )
+        reserve_error_response = _media_reserve_error_response(
+            prepared,
+            message=message,
+            deps=deps,
+            reserve_error=reserve_error,
+            audio_duration_seconds=duration,
+        )
+        if reserve_error_response:
+            return reserve_error_response
 
     transcription, error, billing_segment = deps._transcribe_audio_file(
         audio_file_id,
@@ -1344,15 +1407,23 @@ def _handle_transcribe_command(
     """Handle /transcribe command for audio and images."""
     reserve_credits = 0
     reserve_scope = "vision"
+    audio_file_id: Optional[str] = None
+    audio_duration_seconds = 0.0
     replied_message = cast(Mapping[str, Any], message.get("reply_to_message") or {})
     if replied_message.get("voice") or replied_message.get("audio"):
         reserve_scope = "transcribe"
-        audio_duration_seconds = (
-            _extract_audio_duration_seconds(message)
-            or UNKNOWN_AUDIO_DURATION_ESTIMATE_SECONDS
+        voice = replied_message.get("voice")
+        if isinstance(voice, Mapping):
+            audio_file_id = str(voice.get("file_id") or "") or None
+        audio = replied_message.get("audio")
+        if not audio_file_id and isinstance(audio, Mapping):
+            audio_file_id = str(audio.get("file_id") or "") or None
+        audio_duration_seconds = _extract_audio_duration_seconds(message)
+        admission_duration = (
+            audio_duration_seconds or UNKNOWN_AUDIO_ADMISSION_SECONDS
         )
         reserve_credits = estimate_transcribe_reserve_credits(
-            audio_duration_seconds
+            admission_duration
         )
     else:
         reserve_credits = deps.estimate_image_context_reserve_credits(
@@ -1371,6 +1442,36 @@ def _handle_transcribe_command(
         return deps.handle_rate_limit(chat_id, message), None, False, command
     if media_charge_error:
         return media_charge_error, None, False, command
+
+    if reserve_scope == "transcribe" and audio_duration_seconds <= 0:
+        resolved_duration = _resolve_audio_duration_seconds(
+            message,
+            audio_file_id=audio_file_id,
+            deps=deps,
+        )
+        if resolved_duration is None:
+            billing_helper.refund_reserved_ai_credits(
+                media_charge_meta, reason="transcribe_command_duration_unavailable"
+            )
+            return "ok", None, False, None
+        audio_duration_seconds = resolved_duration
+        required_credits = estimate_transcribe_reserve_credits(
+            audio_duration_seconds
+        )
+        media_charge_meta, media_charge_error = _adjust_media_reservation(
+            deps,
+            billing_helper,
+            reserve_scope,
+            media_charge_meta,
+            reserved_credits=reserve_credits,
+            required_credits=required_credits,
+            reason="transcribe_command_media",
+            metadata={"estimated_audio_seconds": audio_duration_seconds},
+        )
+        if media_charge_error == "rate_limited":
+            return deps.handle_rate_limit(chat_id, message), None, False, command
+        if media_charge_error:
+            return media_charge_error, None, False, command
 
     response_msg, billing_segments = deps.handle_transcribe_with_message_result(
         message
@@ -1620,6 +1721,16 @@ def _handle_known_command(
     return response_msg, response_markup, response_uses_ai, response_command
 
 
+def _route_uses_ai(
+    commands: Mapping[str, CommandTuple], command: str
+) -> bool:
+    if command in _DIRECT_COMMAND_HANDLERS:
+        return False
+    if command in commands:
+        return bool(commands[command][1])
+    return True
+
+
 def _initialize_incoming_message(
     message: Dict[str, Any],
     deps: MessageHandlerDeps,
@@ -1711,7 +1822,10 @@ def _dispatch_message_response(
     prepared_message = _process_message_media(
         runtime.prepared_message,
         message=message,
-        auto_process_media=runtime.auto_process_media,
+        auto_process_media=(
+            runtime.auto_process_media
+            and _route_uses_ai(runtime.commands, intent.command)
+        ),
         deps=deps,
         billing_helper=runtime.billing_helper,
     )

--- a/api/index.py
+++ b/api/index.py
@@ -128,7 +128,9 @@ from api.bot.chat_context import (
 )
 from api.ai.pricing import (
     AIUsageResult,
+    IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE,
     MODEL_PRICING_USD_MICROS,
+    SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE,
     VISION_OUTPUT_TOKEN_LIMIT,
     calculate_billing_for_segments,
     chat_output_token_limit,
@@ -691,35 +693,29 @@ def estimate_ai_base_reserve_credits(
     extra_input_tokens: int = 0,
     timezone_offset: int = -3,
 ) -> Tuple[int, Dict[str, Any]]:
-    system_message: Optional[Dict[str, Any]] = None
-    try:
-        context_data = {
-            "market": get_market_context(),
-            "weather": get_weather_context(),
-            "time": get_time_context(timezone_offset),
-            "hacker_news": get_hacker_news_context(),
-        }
-        system_message = build_system_message(context_data)
-    except Exception as error:
-        print(
-            f"estimate_ai_base_reserve_credits: failed to build system message: {error}"
-        )
-
     reserve = estimate_chat_reserve_credits(
-        system_message=system_message,
+        system_message=None,
         messages=messages,
         max_output_tokens=chat_output_token_limit(PRIMARY_CHAT_MODEL),
-        extra_input_tokens=extra_input_tokens,
+        extra_input_tokens=(
+            extra_input_tokens + SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE
+        ),
         model=PRIMARY_CHAT_MODEL,
     )
 
-    return reserve, {}
+    return reserve, {
+        "estimated_system_context_tokens": SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE,
+        "timezone_offset": timezone_offset,
+    }
 
 
-def estimate_image_context_reserve_credits(image_data: bytes, prompt_text: str) -> int:
+def estimate_image_context_reserve_credits(
+    _image_data: Optional[bytes], prompt_text: str
+) -> int:
     return estimate_vision_reserve_credits(
         prompt_text=prompt_text,
-        image_data=image_data,
+        image_data=None,
+        extra_input_tokens=IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE,
         max_output_tokens=VISION_OUTPUT_TOKEN_LIMIT,
     )
 

--- a/tests/test_ai_requests.py
+++ b/tests/test_ai_requests.py
@@ -214,29 +214,41 @@ def test_estimate_ai_base_reserve_credits_uses_standard_chat_without_forced_sear
     monkeypatch,
 ):
     from api.index import estimate_ai_base_reserve_credits
-    from api.ai.pricing import chat_output_token_limit, estimate_chat_reserve_credits
+    from api.ai.pricing import (
+        SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE,
+        chat_output_token_limit,
+        estimate_chat_reserve_credits,
+    )
 
     messages = [{"role": "user", "content": "CONTEXTO:\nMENSAJE:\nbuscá bitcoin hoy"}]
 
-    monkeypatch.setattr("api.index.get_market_context", lambda: {})
-    monkeypatch.setattr("api.index.get_weather_context", lambda: {})
-    monkeypatch.setattr("api.index.get_time_context", lambda _offset=-3: {"formatted": "Friday"})
-    monkeypatch.setattr("api.index.get_hacker_news_context", lambda: [])
-    monkeypatch.setattr(
-        "api.index.build_system_message",
-        lambda _context_data, **_kw: {"role": "system", "content": "sys"},
-    )
+    context_loaders = [
+        MagicMock(side_effect=AssertionError("market context must not load")),
+        MagicMock(side_effect=AssertionError("weather context must not load")),
+        MagicMock(side_effect=AssertionError("time context must not load")),
+        MagicMock(side_effect=AssertionError("news context must not load")),
+    ]
+    monkeypatch.setattr("api.index.get_market_context", context_loaders[0])
+    monkeypatch.setattr("api.index.get_weather_context", context_loaders[1])
+    monkeypatch.setattr("api.index.get_time_context", context_loaders[2])
+    monkeypatch.setattr("api.index.get_hacker_news_context", context_loaders[3])
 
     reserve, metadata = estimate_ai_base_reserve_credits(messages)
     expected_reserve = estimate_chat_reserve_credits(
-        system_message={"role": "system", "content": "sys"},
+        system_message=None,
         messages=messages,
         max_output_tokens=chat_output_token_limit(index.PRIMARY_CHAT_MODEL),
+        extra_input_tokens=SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE,
         model=index.PRIMARY_CHAT_MODEL,
     )
 
     assert reserve == expected_reserve
-    assert metadata == {}
+    assert metadata == {
+        "estimated_system_context_tokens": SYSTEM_CONTEXT_EXTRA_TOKENS_ESTIMATE,
+        "timezone_offset": -3,
+    }
+    for loader in context_loaders:
+        loader.assert_not_called()
 
 
 def test_ask_ai_fetches_url_unconditionally(monkeypatch):

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -85,6 +85,71 @@ def test_run_summary_rejects_before_history_or_provider_checks():
     stream_summary_command.assert_not_called()
 
 
+def test_run_conversation_rechecks_full_context_before_model_call():
+    from api.ai.service import AIConversationRequest, build_ai_service
+    from api.bot.message_handler import PreparedMessage
+
+    estimator = MagicMock(side_effect=[(2, {}), (5, {})])
+    handle_ai_response = MagicMock()
+    ai_service = build_ai_service(
+        credits_db_service=MagicMock(is_configured=MagicMock(return_value=True)),
+        get_chat_history=MagicMock(
+            return_value=[{"role": "user", "text": "historial largo"}]
+        ),
+        prepare_chat_memory=MagicMock(
+            return_value=([{"role": "user", "text": "historial largo"}], None, [], 0)
+        ),
+        build_ai_messages=MagicMock(
+            return_value=[
+                {"role": "user", "content": "historial largo"},
+                {"role": "user", "content": "hola"},
+            ]
+        ),
+        check_provider_available=MagicMock(return_value=True),
+        has_openrouter_fallback=MagicMock(return_value=False),
+        handle_rate_limit=MagicMock(),
+        handle_ai_response=handle_ai_response,
+        estimate_ai_base_reserve_credits=estimator,
+        estimate_image_context_reserve_credits=MagicMock(return_value=1),
+    )
+    billing_helper = MagicMock()
+    initial_reservation = {
+        "reserved_credit_units": 2,
+        "source": "user",
+        "usage_tag": "ai_response_base",
+    }
+    billing_helper.reserve_ai_credits.side_effect = [
+        (initial_reservation, None),
+        (None, "sin créditos para el contexto"),
+    ]
+
+    response = ai_service.run_conversation(
+        AIConversationRequest(
+            chat_id="902",
+            message={"chat": {"id": 902, "type": "private"}},
+            user_id=10,
+            prepared_message=PreparedMessage("hola", None, None),
+            billing_helper=billing_helper,
+            prompt_text="hola",
+            reply_context_text=None,
+            user_identity="10",
+            handler_func=lambda: None,
+            redis_client=MagicMock(),
+        )
+    )
+
+    assert response == ("sin créditos para el contexto", False)
+    assert billing_helper.reserve_ai_credits.call_count == 2
+    assert billing_helper.reserve_ai_credits.call_args_list[1].args[:2] == (
+        "ai_response_base",
+        5,
+    )
+    billing_helper.refund_reserved_ai_credits.assert_called_once_with(
+        initial_reservation, reason="ai_response_reserve_adjustment"
+    )
+    handle_ai_response.assert_not_called()
+
+
 def test_run_ai_flow_keeps_going_when_openrouter_fallback_is_allowed_for_vision():
     from api.ai.service import AIConversationRequest, build_ai_service
     from api.bot.message_handler import PreparedMessage
@@ -325,4 +390,3 @@ def test_run_conversation_uses_fallback_metadata_not_response_text():
     assert response_msg == fallback_text
     billing_helper.refund_reserved_ai_credits.assert_not_called()
     billing_helper.settle_reserved_ai_credits_batch.assert_called_once()
-

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,6 +1,90 @@
 from tests.support import *
 
 
+def test_run_conversation_rejects_before_history_or_prompt_preparation():
+    from api.ai.service import AIConversationRequest, build_ai_service
+    from api.bot.message_handler import PreparedMessage
+
+    get_chat_history = MagicMock()
+    prepare_chat_memory = MagicMock()
+    build_ai_messages = MagicMock()
+    check_provider_available = MagicMock()
+    handle_ai_response = MagicMock()
+    ai_service = build_ai_service(
+        credits_db_service=MagicMock(is_configured=MagicMock(return_value=True)),
+        get_chat_history=get_chat_history,
+        prepare_chat_memory=prepare_chat_memory,
+        build_ai_messages=build_ai_messages,
+        check_provider_available=check_provider_available,
+        has_openrouter_fallback=MagicMock(),
+        handle_rate_limit=MagicMock(),
+        handle_ai_response=handle_ai_response,
+        estimate_ai_base_reserve_credits=MagicMock(return_value=(3, {})),
+        estimate_image_context_reserve_credits=MagicMock(return_value=1),
+    )
+    billing_helper = MagicMock()
+    billing_helper.reserve_ai_credits.return_value = (None, "sin créditos")
+
+    response = ai_service.run_conversation(
+        AIConversationRequest(
+            chat_id="900",
+            message={"chat": {"id": 900, "type": "private"}},
+            user_id=10,
+            prepared_message=PreparedMessage("hola", None, None),
+            billing_helper=billing_helper,
+            prompt_text="hola",
+            reply_context_text=None,
+            user_identity="10",
+            handler_func=lambda: None,
+            redis_client=MagicMock(),
+        )
+    )
+
+    assert response == ("sin créditos", False)
+    get_chat_history.assert_not_called()
+    prepare_chat_memory.assert_not_called()
+    build_ai_messages.assert_not_called()
+    check_provider_available.assert_not_called()
+    handle_ai_response.assert_not_called()
+
+
+def test_run_summary_rejects_before_history_or_provider_checks():
+    from api.ai.service import SummaryCommandRequest, build_ai_service
+
+    stream_summary_command = MagicMock()
+    check_provider_available = MagicMock()
+    ai_service = build_ai_service(
+        credits_db_service=MagicMock(is_configured=MagicMock(return_value=True)),
+        get_chat_history=MagicMock(),
+        prepare_chat_memory=MagicMock(),
+        build_ai_messages=MagicMock(),
+        check_provider_available=check_provider_available,
+        has_openrouter_fallback=MagicMock(),
+        handle_rate_limit=MagicMock(),
+        handle_ai_response=MagicMock(),
+        estimate_ai_base_reserve_credits=MagicMock(return_value=(3, {})),
+        estimate_image_context_reserve_credits=MagicMock(return_value=1),
+        stream_summary_command=stream_summary_command,
+    )
+    billing_helper = MagicMock()
+    billing_helper.reserve_ai_credits.return_value = (None, "sin créditos")
+
+    response = ai_service.run_summary_command_stream(
+        SummaryCommandRequest(
+            chat_id="901",
+            message={"chat": {"id": 901, "type": "private"}},
+            billing_helper=billing_helper,
+            prompt_text="resumí",
+            redis_client=MagicMock(),
+        ),
+        stream_consumer=MagicMock(),
+    )
+
+    assert response == ("sin créditos", None, True)
+    check_provider_available.assert_not_called()
+    stream_summary_command.assert_not_called()
+
+
 def test_run_ai_flow_keeps_going_when_openrouter_fallback_is_allowed_for_vision():
     from api.ai.service import AIConversationRequest, build_ai_service
     from api.bot.message_handler import PreparedMessage
@@ -241,5 +325,4 @@ def test_run_conversation_uses_fallback_metadata_not_response_text():
     assert response_msg == fallback_text
     billing_helper.refund_reserved_ai_credits.assert_not_called()
     billing_helper.settle_reserved_ai_credits_batch.assert_called_once()
-
 

--- a/tests/test_message_ai_media.py
+++ b/tests/test_message_ai_media.py
@@ -6,6 +6,43 @@ from tests.message_handler_support import (
 )
 
 
+def test_handle_msg_image_rejects_before_download_or_history(monkeypatch):
+    from api.bot.message_handler import handle_msg
+
+    redis_client = MagicMock()
+    mock_send_msg = MagicMock()
+    mock_download = MagicMock()
+    mock_history = MagicMock()
+    mock_credits = MagicMock()
+    mock_credits.is_configured.return_value = True
+    mock_credits.charge_ai_credits.return_value = {
+        "ok": False,
+        "user_balance_credit_units": 0,
+        "chat_balance_credit_units": 0,
+    }
+
+    monkeypatch.setenv("TELEGRAM_USERNAME", "testbot")
+
+    make_deps, _ = _build_message_handler_deps()
+    deps = make_deps(
+        config_redis=lambda: redis_client,
+        send_msg=mock_send_msg,
+        download_telegram_file=mock_download,
+        should_gordo_respond=MagicMock(return_value=True),
+        credits_db_service=mock_credits,
+        get_chat_history=mock_history,
+    )
+
+    result = handle_msg(
+        _private_photo_message(message_id=21, chat_id=555, user_id=98), deps
+    )
+
+    assert result == "ok"
+    mock_download.assert_not_called()
+    mock_history.assert_not_called()
+    mock_send_msg.assert_called_once()
+
+
 def test_handle_msg_image_conversation_charges_media_and_response_credits(monkeypatch):
     from api.bot.message_handler import handle_msg
 
@@ -625,7 +662,7 @@ def test_handle_msg_transcribe_image_does_not_preprocess_image_or_double_charge(
     result = handle_msg(message, deps)
 
     assert result == "ok"
-    mock_download.assert_called_once_with("img_reply")
+    mock_download.assert_not_called()
     assert mock_charge.call_count == 1
     assert mock_charge.call_args.kwargs["amount"] == 1
     mock_send_msg.assert_called_once()

--- a/tests/test_message_ai_media.py
+++ b/tests/test_message_ai_media.py
@@ -43,6 +43,38 @@ def test_handle_msg_image_rejects_before_download_or_history(monkeypatch):
     mock_send_msg.assert_called_once()
 
 
+def test_handle_msg_non_ai_command_with_photo_skips_media_billing(monkeypatch):
+    from api.bot.message_handler import handle_msg
+
+    redis_client = MagicMock()
+    mock_send_msg = MagicMock()
+    mock_download = MagicMock()
+    mock_credits = MagicMock()
+    mock_credits.is_configured.return_value = True
+
+    monkeypatch.setenv("TELEGRAM_USERNAME", "testbot")
+
+    make_deps, _ = _build_message_handler_deps()
+    deps = make_deps(
+        config_redis=lambda: redis_client,
+        send_msg=mock_send_msg,
+        download_telegram_file=mock_download,
+        credits_db_service=mock_credits,
+        balance_formatter=MagicMock(
+            format=MagicMock(return_value="balance info")
+        ),
+    )
+    message = _private_photo_message(message_id=20, chat_id=555, user_id=97)
+    message["caption"] = "/balance"
+
+    result = handle_msg(message, deps)
+
+    assert result == "ok"
+    mock_download.assert_not_called()
+    mock_credits.charge_ai_credits.assert_not_called()
+    mock_send_msg.assert_called_once()
+
+
 def test_handle_msg_image_conversation_charges_media_and_response_credits(monkeypatch):
     from api.bot.message_handler import handle_msg
 

--- a/tests/test_message_transcription.py
+++ b/tests/test_message_transcription.py
@@ -135,6 +135,9 @@ def test_handle_msg_with_image(monkeypatch):
         ),
         check_provider_available=MagicMock(return_value=True),
         credits_db_service=mock_credits,
+        handle_ai_response=_simulate_streamed_ai_response(
+            mock_send_msg, "A beautiful landscape"
+        ),
     )
     message = _private_photo_message(message_id=1, user_id=11, file_id="photo_123")
 
@@ -378,7 +381,7 @@ def test_handle_msg_with_transcribe_command_refunds_on_unsuccessful_response(
     mock_send_msg.assert_called_once()
 
 
-def test_handle_msg_with_transcribe_command_rejects_audio_without_duration(monkeypatch):
+def test_handle_msg_with_transcribe_command_reserves_before_unknown_duration(monkeypatch):
     from api.bot.message_handler import handle_msg
 
     redis_client = MagicMock()
@@ -388,6 +391,10 @@ def test_handle_msg_with_transcribe_command_rejects_audio_without_duration(monke
     mock_download = MagicMock(return_value=b"audio-bytes")
     mock_credits = MagicMock()
     mock_credits.is_configured.return_value = True
+    mock_credits.charge_ai_credits.return_value = {"ok": True, "source": "user"}
+    mock_handle_transcribe = MagicMock(
+        return_value=("no pude sacar nada de ese audio, probá más tarde", [])
+    )
 
     monkeypatch.setenv("TELEGRAM_USERNAME", "testbot")
 
@@ -395,7 +402,7 @@ def test_handle_msg_with_transcribe_command_rejects_audio_without_duration(monke
     deps = make_deps(
         config_redis=lambda: redis_client,
         send_msg=mock_send_msg,
-        handle_transcribe_with_message_result=MagicMock(),
+        handle_transcribe_with_message_result=mock_handle_transcribe,
         download_telegram_file=mock_download,
         measure_audio_duration_seconds=MagicMock(return_value=None),
         credits_db_service=mock_credits,
@@ -411,7 +418,9 @@ def test_handle_msg_with_transcribe_command_rejects_audio_without_duration(monke
     result = handle_msg(message, deps)
 
     assert result == "ok"
-    mock_credits.charge_ai_credits.assert_not_called()
+    mock_credits.charge_ai_credits.assert_called_once()
+    mock_handle_transcribe.assert_called_once_with(message)
+    mock_download.assert_not_called()
 
 
 def test_handle_msg_auto_audio_charges_media_credits(monkeypatch):
@@ -458,16 +467,23 @@ def test_handle_msg_auto_audio_charges_media_credits(monkeypatch):
     mock_send_msg.assert_called_once()
 
 
-def test_handle_msg_auto_audio_rejects_missing_duration(monkeypatch):
+def test_handle_msg_auto_audio_reserves_before_measuring_missing_duration(monkeypatch):
     from api.bot.message_handler import handle_msg
 
     redis_client = MagicMock()
     redis_client.get.return_value = json.dumps(CHAT_CONFIG_DEFAULTS)
     redis_client.lrange.return_value = []
     mock_send_msg = MagicMock()
-    mock_download = MagicMock(return_value=b"audio-bytes")
+    events = []
+    mock_download = MagicMock(
+        side_effect=lambda _file_id: events.append("download") or b"audio-bytes"
+    )
     mock_credits = MagicMock()
     mock_credits.is_configured.return_value = True
+    mock_credits.charge_ai_credits.side_effect = lambda **_kwargs: (
+        events.append("reserve")
+        or {"ok": True, "source": "user"}
+    )
 
     monkeypatch.setenv("TELEGRAM_USERNAME", "testbot")
 
@@ -485,7 +501,8 @@ def test_handle_msg_auto_audio_rejects_missing_duration(monkeypatch):
     result = handle_msg(message, deps)
 
     assert result == "ok"
-    mock_credits.charge_ai_credits.assert_not_called()
+    assert events == ["reserve", "download"]
+    mock_credits.refund_ai_charge.assert_called_once()
 
 
 def test_handle_msg_auto_audio_measures_duration_when_missing_in_message(monkeypatch):

--- a/tests/test_message_transcription.py
+++ b/tests/test_message_transcription.py
@@ -381,7 +381,7 @@ def test_handle_msg_with_transcribe_command_refunds_on_unsuccessful_response(
     mock_send_msg.assert_called_once()
 
 
-def test_handle_msg_with_transcribe_command_reserves_before_unknown_duration(monkeypatch):
+def test_handle_msg_with_transcribe_command_refunds_when_duration_is_unknown(monkeypatch):
     from api.bot.message_handler import handle_msg
 
     redis_client = MagicMock()
@@ -419,8 +419,59 @@ def test_handle_msg_with_transcribe_command_reserves_before_unknown_duration(mon
 
     assert result == "ok"
     mock_credits.charge_ai_credits.assert_called_once()
-    mock_handle_transcribe.assert_called_once_with(message)
-    mock_download.assert_not_called()
+    mock_credits.refund_ai_charge.assert_called_once()
+    mock_handle_transcribe.assert_not_called()
+    mock_download.assert_called_once_with("voice_123")
+
+
+def test_transcribe_unknown_duration_reserves_measured_cost_before_ai(monkeypatch):
+    from api.bot.message_handler import handle_msg
+
+    redis_client = MagicMock()
+    mock_send_msg = MagicMock()
+    mock_handle_transcribe = MagicMock()
+    mock_credits = MagicMock()
+    mock_credits.is_configured.return_value = True
+    mock_credits.charge_ai_credits.side_effect = [
+        {"ok": True, "source": "user"},
+        {
+            "ok": False,
+            "user_balance_credit_units": 0,
+            "chat_balance_credit_units": 0,
+        },
+    ]
+
+    monkeypatch.setenv("TELEGRAM_USERNAME", "testbot")
+
+    make_deps, _ = _build_message_handler_deps()
+    deps = make_deps(
+        config_redis=lambda: redis_client,
+        send_msg=mock_send_msg,
+        handle_transcribe_with_message_result=mock_handle_transcribe,
+        download_telegram_file=MagicMock(return_value=b"audio-bytes"),
+        measure_audio_duration_seconds=MagicMock(return_value=120.0),
+        credits_db_service=mock_credits,
+    )
+    message = {
+        "message_id": 2,
+        "chat": {"id": 123, "type": "private"},
+        "from": {"id": 177, "first_name": "John", "username": "john"},
+        "text": "/transcribe",
+        "reply_to_message": {
+            "message_id": 3,
+            "voice": {"file_id": "voice_123"},
+        },
+    }
+
+    result = handle_msg(message, deps)
+
+    assert result == "ok"
+    assert mock_credits.charge_ai_credits.call_count == 2
+    initial_amount = mock_credits.charge_ai_credits.call_args_list[0].kwargs["amount"]
+    measured_amount = mock_credits.charge_ai_credits.call_args_list[1].kwargs["amount"]
+    assert measured_amount > initial_amount
+    mock_credits.refund_ai_charge.assert_called_once()
+    mock_handle_transcribe.assert_not_called()
 
 
 def test_handle_msg_auto_audio_charges_media_credits(monkeypatch):


### PR DESCRIPTION
## Summary

- reserve AI credits before history loading, compaction, provider checks, and prompt preparation
- make chat and vision reserve estimation local and side-effect free
- reserve media credits before downloads, resizing, and duration measurement
- refund reservations when preparation fails or providers are unavailable
- add behavioral coverage for rejected chat, summary, image, and audio requests

## Root cause

The credit reservation ran after expensive request preparation. `/resumen` could load and search history, compact memory with an AI model, and fetch prompt context before discovering that the user and group did not have enough credits.

## Impact

Insufficient-credit responses now use the atomic reservation as the admission check and return before expensive AI or media work starts. Scheduled tasks and generated alerts also use the pure shared estimator before their existing reservation step.

## Validation

- `pytest -q` — 872 passed
- `.venv/bin/ruff check api/ tests/` — passed
- `git diff --check` — passed

Mypy still reports two pre-existing errors in `api/services/maintenance.py`; this PR does not modify that file.