### PR TITLE
Improve AI tool reliability and background compaction

### DIFF
--- a/api/ai/service.py
+++ b/api/ai/service.py
@@ -10,29 +10,17 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from api.ai.pricing import IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE, credit_units_from_usd_micros
+from api.ai.pricing import IMAGE_CONTEXT_EXTRA_TOKENS_ESTIMATE
 
 
 _summary_logger = logging.getLogger(__name__)
-
-
-def _make_summary_billing_segment(cost_usd_micros: int) -> Dict[str, Any]:
-    return {
-        "kind": "summary",
-        "text": "context compaction",
-        "usage": {"input_tokens": 0, "output_tokens": 0},
-        "billing": {
-            "raw_usd_micros": cost_usd_micros,
-            "charged_credit_units": credit_units_from_usd_micros(cost_usd_micros),
-        },
-    }
 
 
 @dataclass(frozen=True)
 class AIService:
     credits_db_service: Any
     get_chat_history: Callable[[str, Any], List[Dict[str, Any]]]
-    prepare_chat_memory: Callable[..., Tuple[List[Dict[str, Any]], Optional[str], List[Dict[str, Any]], int]]
+    prepare_chat_memory: Callable[..., Any]
     build_ai_messages: Callable[..., List[Dict[str, Any]]]
     check_provider_available: Callable[..., bool]
     has_openrouter_fallback: Callable[[], bool]
@@ -41,6 +29,7 @@ class AIService:
     estimate_ai_base_reserve_credits: Callable[..., Tuple[int, Dict[str, Any]]]
     estimate_image_context_reserve_credits: Callable[[bytes, str], int]
     stream_summary_command: Callable[[str, Any, str], Any]
+    schedule_compaction: Callable[[Any, Any], bool]
 
     @staticmethod
     def _refund_if_present(
@@ -56,7 +45,7 @@ class AIService:
 
     def _prepare_conversation_messages(
         self, request: AIConversationRequest
-    ) -> Tuple[List[Dict[str, Any]], int]:
+    ) -> Tuple[List[Dict[str, Any]], Any]:
         chat_history = self.get_chat_history(request.chat_id, request.redis_client)
         reply_to_message = (
             request.message.get("reply_to_message") if request.message else None
@@ -66,17 +55,17 @@ class AIService:
             raw_reply_to_id = reply_to_message.get("message_id")
             if raw_reply_to_id is not None:
                 reply_to_message_id = str(raw_reply_to_id)
-        visible_history, summary_text, retrieved_messages, summary_cost = (
-            self.prepare_chat_memory(
-                request.redis_client,
-                request.chat_id,
-                chat_history,
-                request.prompt_text,
-                reply_to_message_id=reply_to_message_id,
-                compaction_threshold=request.compaction_threshold,
-                compaction_keep=request.compaction_keep,
-            )
+        prepared = self.prepare_chat_memory(
+            request.redis_client,
+            request.chat_id,
+            chat_history,
+            request.prompt_text,
+            reply_to_message_id=reply_to_message_id,
+            compaction_threshold=request.compaction_threshold,
+            compaction_keep=request.compaction_keep,
         )
+        visible_history, summary_text, retrieved_messages = prepared[:3]
+        compaction_plan = prepared[4] if len(prepared) > 4 else None
         messages = self.build_ai_messages(
             request.message,
             visible_history,
@@ -86,7 +75,7 @@ class AIService:
             retrieved_messages=retrieved_messages,
             timezone_offset=request.timezone_offset,
         )
-        return messages, summary_cost
+        return messages, compaction_plan
 
     def _reserve_image_context(
         self,
@@ -140,8 +129,6 @@ class AIService:
         self,
         request: AIConversationRequest,
         messages: List[Dict[str, Any]],
-        *,
-        summary_cost_usd_micros: int,
     ) -> Tuple[int, Dict[str, Any]]:
         full_reserve_credits, reserve_meta = (
             self.estimate_ai_base_reserve_credits(
@@ -154,13 +141,9 @@ class AIService:
                 timezone_offset=request.timezone_offset,
             )
         )
-        required_credits = full_reserve_credits + credit_units_from_usd_micros(
-            summary_cost_usd_micros
-        )
-        return required_credits, {
+        return full_reserve_credits, {
             "estimated_prompt_messages": len(messages),
-            "required_reserve_credits": required_credits,
-            "summary_cost_usd_micros": summary_cost_usd_micros,
+            "required_reserve_credits": full_reserve_credits,
             **reserve_meta,
         }
 
@@ -222,7 +205,7 @@ class AIService:
             return ("ok", False) if request.is_spontaneous else (rate_limit_msg, False)
 
         try:
-            ai_messages, summary_cost = self._prepare_conversation_messages(request)
+            ai_messages, compaction_plan = self._prepare_conversation_messages(request)
         except Exception:
             request.billing_helper.refund_reserved_ai_credits(
                 base_charge_meta, reason="ai_request_preparation_failed"
@@ -236,7 +219,6 @@ class AIService:
             self._estimate_full_conversation_reserve(
                 request,
                 ai_messages,
-                summary_cost_usd_micros=summary_cost,
             )
         )
         if full_reserve_credits > main_reserve_credits:
@@ -285,8 +267,6 @@ class AIService:
         )
 
         billing_segments = list(ai_response_meta.get("billing_segments") or [])
-        if summary_cost > 0:
-            billing_segments.insert(0, _make_summary_billing_segment(summary_cost))
         if bool(ai_response_meta.get("ai_fallback")):
             # The local fallback has no provider usage, so release every reserve.
             self._refund_if_present(
@@ -306,6 +286,16 @@ class AIService:
             billing_segments,
             reason="ai_response_success",
         )
+
+        try:
+            self.schedule_compaction(compaction_plan, request.billing_helper)
+        except Exception:
+            # Compaction is maintenance. It must not turn a successful answer
+            # into an error or add a model call to the foreground path.
+            _summary_logger.exception(
+                "compaction: failed to schedule chat_id=%s",
+                request.chat_id,
+            )
 
         return response_msg, True
 
@@ -412,7 +402,7 @@ def build_ai_service(
     *,
     credits_db_service: Any,
     get_chat_history: Callable[[str, Any], List[Dict[str, Any]]],
-    prepare_chat_memory: Callable[..., Tuple[List[Dict[str, Any]], Optional[str], List[Dict[str, Any]], int]],
+    prepare_chat_memory: Callable[..., Any],
     build_ai_messages: Callable[..., List[Dict[str, Any]]],
     check_provider_available: Callable[..., bool],
     has_openrouter_fallback: Callable[[], bool],
@@ -421,6 +411,7 @@ def build_ai_service(
     estimate_ai_base_reserve_credits: Callable[..., Tuple[int, Dict[str, Any]]],
     estimate_image_context_reserve_credits: Callable[[bytes, str], int],
     stream_summary_command: Callable[[str, Any, str], Any] = lambda _a, _b, _c: (iter([]), None),
+    schedule_compaction: Callable[[Any, Any], bool] = lambda _plan, _billing: False,
 ) -> AIService:
     return AIService(
         credits_db_service=credits_db_service,
@@ -434,4 +425,5 @@ def build_ai_service(
         estimate_ai_base_reserve_credits=estimate_ai_base_reserve_credits,
         estimate_image_context_reserve_credits=estimate_image_context_reserve_credits,
         stream_summary_command=stream_summary_command,
+        schedule_compaction=schedule_compaction,
     )

--- a/api/billing/ai.py
+++ b/api/billing/ai.py
@@ -400,6 +400,38 @@ class AIMessageBilling:
     ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
         """Reserve a worst-case number of credits for a billable interaction."""
 
+        return self._reserve_ai_credits(
+            usage_tag,
+            estimated_credit_units,
+            metadata=metadata,
+            enforce_message_cap=True,
+        )
+
+    def reserve_background_ai_credits(
+        self,
+        usage_tag: str,
+        estimated_credit_units: int,
+        *,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        """Reserve maintenance work without counting another user message."""
+
+        return self._reserve_ai_credits(
+            usage_tag,
+            estimated_credit_units,
+            metadata=metadata,
+            enforce_message_cap=False,
+        )
+
+    def _reserve_ai_credits(
+        self,
+        usage_tag: str,
+        estimated_credit_units: int,
+        *,
+        metadata: Optional[Mapping[str, Any]],
+        enforce_message_cap: bool,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+
         chat_scope_id, context_error = self._resolve_ai_charge_context()
         if context_error:
             return None, context_error
@@ -462,7 +494,7 @@ class AIMessageBilling:
             "metadata": reserve_metadata,
         }
 
-        if source == "chat":
+        if source == "chat" and enforce_message_cap:
             cap_error = self._check_creditless_cap(
                 chat_scope_id=chat_scope_id,
                 reserve_amount=reserve_amount,

--- a/api/index.py
+++ b/api/index.py
@@ -330,6 +330,7 @@ def make_chat_tz(offset: int = -3) -> timezone:
 PRIMARY_CHAT_MODEL = "~deepseek/deepseek-v4-flash-latest"
 SUMMARY_MODEL = "~deepseek/deepseek-v4-flash-latest"
 SUMMARY_MAX_TOKENS = 2048
+COMPACTION_TIMEOUT_SECONDS = 600.0
 COMPACTION_THRESHOLD = 40
 COMPACTION_KEEP = 25
 COMPACTION_TRUNCATE_LINES = 25
@@ -1014,6 +1015,9 @@ _summary_service = SummaryService(
         truncate_lines=COMPACTION_TRUNCATE_LINES,
         no_markdown_prompt=PROMPT_NO_MARKDOWN,
         pricing_by_model=MODEL_PRICING_USD_MICROS,
+        redis_factory=_config_runtime.redis,
+        credits=credits_db_service,
+        compaction_timeout_seconds=COMPACTION_TIMEOUT_SECONDS,
     )
 )
 _ai_request_service = AIRequestService(
@@ -1225,6 +1229,7 @@ def _build_message_handler_deps() -> MessageHandlerDeps:
         estimate_ai_base_reserve_credits=estimate_ai_base_reserve_credits,
         estimate_image_context_reserve_credits=estimate_image_context_reserve_credits,
         stream_summary_command=_summary_service.stream_command,
+        schedule_compaction=_summary_service.schedule_compaction,
     )
     return build_message_handler_deps(
         chat=MessageChatDeps(

--- a/api/memory/background.py
+++ b/api/memory/background.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import threading
 import time
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from typing import Any, Callable
 from uuid import uuid4
@@ -48,7 +49,7 @@ class DurableCompactionQueue:
         get_marker: Callable[[Any, str], str | None],
         save_result: Callable[[Any, str, str, str], None],
         estimate_reserve: Callable[[CompactionPlan], int],
-        credits: Any,
+        settle_reservation: Callable[..., Mapping[str, Any]],
         logger: Any,
     ) -> None:
         self._redis_factory = redis_factory
@@ -57,7 +58,7 @@ class DurableCompactionQueue:
         self._get_marker = get_marker
         self._save_result = save_result
         self._estimate_reserve = estimate_reserve
-        self._credits = credits
+        self._settle_reservation = settle_reservation
         self._logger = logger
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
@@ -75,7 +76,7 @@ class DurableCompactionQueue:
 
         reserve_units = max(1, self._estimate_reserve(plan))
         usage_tag = f"memory_compaction:{plan.chat_id}:{plan.target_marker}"
-        reservation, error_message = billing.reserve_ai_credits(
+        reservation, error_message = billing.reserve_background_ai_credits(
             usage_tag,
             reserve_units,
             metadata={
@@ -111,9 +112,16 @@ class DurableCompactionQueue:
             self._logger.warning("compaction: failed to persist job: %s", error)
             stored = False
         if not stored:
-            billing.refund_reserved_ai_credits(
-                reservation,
-                reason="memory_compaction_enqueue_failed",
+            self._settle_reservation(
+                user_id=int(billing.user_id),
+                chat_id=reservation.get("chat_scope_id"),
+                source=str(reservation.get("source") or "user"),
+                reserved_credit_units=int(
+                    reservation.get("reserved_credit_units") or 0
+                ),
+                actual_credit_units=0,
+                usage_tag=str(reservation.get("usage_tag") or usage_tag),
+                metadata={"reason": "memory_compaction_enqueue_failed"},
             )
         return stored
 
@@ -143,10 +151,18 @@ class DurableCompactionQueue:
             if not chat_id or not payload:
                 continue
             try:
-                job = CompactionJob(**json.loads(payload))
-            except Exception:
-                self._logger.exception("compaction: invalid job chat_id=%s", chat_id)
-                client.hdel(_JOBS_KEY, chat_id)
+                decoded = json.loads(payload)
+            except (TypeError, json.JSONDecodeError):
+                # Keep undecodable data. Deleting it could discard the only
+                # copy of a paid reservation that an operator can recover.
+                self._logger.exception("compaction: undecodable job chat_id=%s", chat_id)
+                continue
+            try:
+                job = CompactionJob(**decoded)
+            except (TypeError, ValueError):
+                self._logger.exception("compaction: incompatible job chat_id=%s", chat_id)
+                if self._settle_invalid_job(decoded, chat_id=chat_id):
+                    client.hdel(_JOBS_KEY, chat_id)
                 continue
             if job.next_attempt_at > time.time():
                 continue
@@ -177,10 +193,10 @@ class DurableCompactionQueue:
         ):
             # The process stopped after saving memory but before deleting the
             # durable job. Finish its billing instead of refunding it.
-            self._settle(job)
+            self._settle(job, reason="memory_compaction_success")
             return
         if current_summary != job.prior_summary or current_marker != job.expected_marker:
-            self._refund(job, reason="memory_compaction_obsolete")
+            self._settle(job, actual_credit_units=0, reason="memory_compaction_obsolete")
             return
 
         if not job.result_summary:
@@ -201,7 +217,7 @@ class DurableCompactionQueue:
             job.result_summary,
             job.target_marker,
         )
-        self._settle(job)
+        self._settle(job, reason="memory_compaction_success")
         self._logger.info(
             "compaction: completed chat_id=%s target=%s attempts=%d cost_usd_micros=%d",
             job.chat_id,
@@ -220,7 +236,7 @@ class DurableCompactionQueue:
             error,
         )
         if job.attempts >= _MAX_ATTEMPTS:
-            self._refund(job, reason="memory_compaction_failed")
+            self._settle(job, actual_credit_units=0, reason="memory_compaction_failed")
             client.hdel(_JOBS_KEY, job.chat_id)
             return
         job.next_attempt_at = time.time() + 30 * (2 ** (job.attempts - 1))
@@ -230,46 +246,65 @@ class DurableCompactionQueue:
             json.dumps(asdict(job), ensure_ascii=False),
         )
 
-    def _settle(self, job: CompactionJob) -> None:
-        reserved = int(job.reservation.get("reserved_credit_units") or 0)
-        actual = credit_units_from_usd_micros(job.result_cost_usd_micros)
-        if actual < reserved:
-            self._refund(job, amount=reserved - actual, reason="memory_compaction_success")
-        elif actual > reserved:
-            self._credits.charge_ai_credits(
-                user_id=job.user_id,
-                chat_id=job.reservation.get("chat_scope_id"),
-                amount=actual - reserved,
-                event_type="ai_settlement_charge",
-                metadata={"usage_tag": job.reservation.get("usage_tag")},
-            )
-
-    def _refund(
+    def _settle(
         self,
         job: CompactionJob,
         *,
         reason: str,
-        amount: int | None = None,
+        actual_credit_units: int | None = None,
     ) -> None:
-        refund_amount = (
-            int(job.reservation.get("reserved_credit_units") or 0)
-            if amount is None
-            else max(0, int(amount))
+        actual = (
+            credit_units_from_usd_micros(job.result_cost_usd_micros)
+            if actual_credit_units is None
+            else max(0, int(actual_credit_units))
         )
-        if refund_amount <= 0:
-            return
-        self._credits.refund_ai_charge(
+        self._settle_reservation(
             user_id=job.user_id,
             chat_id=job.reservation.get("chat_scope_id"),
-            amount=refund_amount,
             source=str(job.reservation.get("source") or "user"),
-            event_type="ai_refund",
+            reserved_credit_units=int(
+                job.reservation.get("reserved_credit_units") or 0
+            ),
+            actual_credit_units=actual,
+            usage_tag=str(job.reservation.get("usage_tag") or ""),
             metadata={
-                "usage_tag": job.reservation.get("usage_tag"),
                 "reason": reason,
                 "message_id": job.message_id,
             },
         )
+
+    def _settle_invalid_job(self, decoded: Any, *, chat_id: str) -> bool:
+        if not isinstance(decoded, Mapping):
+            return False
+        reservation = decoded.get("reservation")
+        if not isinstance(reservation, Mapping) or decoded.get("user_id") is None:
+            return False
+        usage_tag = str(reservation.get("usage_tag") or "")
+        if not usage_tag:
+            return False
+        try:
+            self._settle_reservation(
+                user_id=int(decoded["user_id"]),
+                chat_id=reservation.get("chat_scope_id"),
+                source=str(reservation.get("source") or "user"),
+                reserved_credit_units=int(
+                    reservation.get("reserved_credit_units") or 0
+                ),
+                actual_credit_units=0,
+                usage_tag=usage_tag,
+                metadata={
+                    "reason": "memory_compaction_incompatible_job",
+                    "chat_id": chat_id,
+                },
+            )
+            return True
+        except Exception as error:
+            self._logger.warning(
+                "compaction: failed to settle incompatible job chat_id=%s error=%s",
+                chat_id,
+                error,
+            )
+            return False
 
     def _run(self) -> None:
         while not self._stop.is_set():

--- a/api/memory/background.py
+++ b/api/memory/background.py
@@ -15,6 +15,7 @@ from api.memory.compaction import CompactionPlan
 
 
 _JOBS_KEY = "memory:compaction:jobs"
+_DEAD_JOBS_KEY = "memory:compaction:dead_jobs"
 _LOCK_PREFIX = "memory:compaction:lock:"
 _LOCK_TTL_SECONDS = 60 * 60
 _POLL_SECONDS = 2.0
@@ -75,7 +76,9 @@ class DurableCompactionQueue:
             return False
 
         reserve_units = max(1, self._estimate_reserve(plan))
-        usage_tag = f"memory_compaction:{plan.chat_id}:{plan.target_marker}"
+        usage_tag = (
+            f"memory_compaction:{plan.chat_id}:{plan.target_marker}:{uuid4().hex}"
+        )
         reservation, error_message = billing.reserve_background_ai_credits(
             usage_tag,
             reserve_units,
@@ -153,9 +156,12 @@ class DurableCompactionQueue:
             try:
                 decoded = json.loads(payload)
             except (TypeError, json.JSONDecodeError):
-                # Keep undecodable data. Deleting it could discard the only
-                # copy of a paid reservation that an operator can recover.
-                self._logger.exception("compaction: undecodable job chat_id=%s", chat_id)
+                self._quarantine_job(
+                    client,
+                    chat_id=chat_id,
+                    payload=payload,
+                    reason="undecodable",
+                )
                 continue
             try:
                 job = CompactionJob(**decoded)
@@ -305,6 +311,44 @@ class DurableCompactionQueue:
                 error,
             )
             return False
+
+    def _quarantine_job(
+        self,
+        client: Any,
+        *,
+        chat_id: str,
+        payload: str,
+        reason: str,
+    ) -> bool:
+        """Move an unreadable job out of the active queue without losing it."""
+
+        dead_job_id = f"{chat_id}:{uuid4().hex}"
+        dead_payload = json.dumps(
+            {
+                "chat_id": chat_id,
+                "payload": payload,
+                "reason": reason,
+                "quarantined_at": time.time(),
+            },
+            ensure_ascii=False,
+        )
+        try:
+            client.hset(_DEAD_JOBS_KEY, dead_job_id, dead_payload)
+            client.hdel(_JOBS_KEY, chat_id)
+        except Exception as error:
+            self._logger.warning(
+                "compaction: failed to quarantine job chat_id=%s error=%s",
+                chat_id,
+                error,
+            )
+            return False
+        self._logger.warning(
+            "compaction: quarantined job chat_id=%s reason=%s dead_job_id=%s",
+            chat_id,
+            reason,
+            dead_job_id,
+        )
+        return True
 
     def _run(self) -> None:
         while not self._stop.is_set():

--- a/api/memory/background.py
+++ b/api/memory/background.py
@@ -1,0 +1,286 @@
+"""Durable, user-funded conversation compaction jobs."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Callable
+from uuid import uuid4
+
+from api.ai.pricing import credit_units_from_usd_micros
+from api.memory.compaction import CompactionPlan
+
+
+_JOBS_KEY = "memory:compaction:jobs"
+_LOCK_PREFIX = "memory:compaction:lock:"
+_LOCK_TTL_SECONDS = 60 * 60
+_POLL_SECONDS = 2.0
+_MAX_ATTEMPTS = 3
+
+
+@dataclass
+class CompactionJob:
+    chat_id: str
+    messages: list[dict[str, Any]]
+    prior_summary: str | None
+    expected_marker: str | None
+    target_marker: str
+    reservation: dict[str, Any]
+    user_id: int
+    message_id: str | None
+    attempts: int = 0
+    next_attempt_at: float = 0.0
+    result_summary: str | None = None
+    result_cost_usd_micros: int = 0
+
+
+class DurableCompactionQueue:
+    """Keep compaction jobs in Redis and process them outside answer latency."""
+
+    def __init__(
+        self,
+        *,
+        redis_factory: Callable[[], Any],
+        compact: Callable[[list[dict[str, Any]], str | None], tuple[str, int]],
+        get_summary: Callable[[Any, str], str | None],
+        get_marker: Callable[[Any, str], str | None],
+        save_result: Callable[[Any, str, str, str], None],
+        estimate_reserve: Callable[[CompactionPlan], int],
+        credits: Any,
+        logger: Any,
+    ) -> None:
+        self._redis_factory = redis_factory
+        self._compact = compact
+        self._get_summary = get_summary
+        self._get_marker = get_marker
+        self._save_result = save_result
+        self._estimate_reserve = estimate_reserve
+        self._credits = credits
+        self._logger = logger
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def enqueue(self, plan: CompactionPlan, billing: Any) -> bool:
+        """Reserve the payer's credits and persist one job per chat."""
+
+        try:
+            client = self._redis_factory()
+            if client.hexists(_JOBS_KEY, plan.chat_id):
+                return False
+        except Exception as error:
+            self._logger.warning("compaction: Redis unavailable before reserve: %s", error)
+            return False
+
+        reserve_units = max(1, self._estimate_reserve(plan))
+        usage_tag = f"memory_compaction:{plan.chat_id}:{plan.target_marker}"
+        reservation, error_message = billing.reserve_ai_credits(
+            usage_tag,
+            reserve_units,
+            metadata={
+                "target_marker": plan.target_marker,
+                "message_count": len(plan.messages),
+                "background": True,
+            },
+        )
+        if error_message or not reservation:
+            self._logger.info(
+                "compaction: skipped unfunded job chat_id=%s target=%s",
+                plan.chat_id,
+                plan.target_marker,
+            )
+            return False
+
+        raw_message_id = getattr(billing, "message", {}).get("message_id")
+        job = CompactionJob(
+            **asdict(plan),
+            reservation=dict(reservation),
+            user_id=int(billing.user_id),
+            message_id=str(raw_message_id) if raw_message_id is not None else None,
+        )
+        try:
+            stored = bool(
+                client.hsetnx(
+                    _JOBS_KEY,
+                    plan.chat_id,
+                    json.dumps(asdict(job), ensure_ascii=False),
+                )
+            )
+        except Exception as error:
+            self._logger.warning("compaction: failed to persist job: %s", error)
+            stored = False
+        if not stored:
+            billing.refund_reserved_ai_credits(
+                reservation,
+                reason="memory_compaction_enqueue_failed",
+            )
+        return stored
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="memory-compaction",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=5)
+
+    def run_pending_once(self) -> int:
+        client = self._redis_factory()
+        raw_jobs = client.hgetall(_JOBS_KEY) or {}
+        processed = 0
+        for raw_chat_id, raw_payload in raw_jobs.items():
+            chat_id = self._text(raw_chat_id)
+            payload = self._text(raw_payload)
+            if not chat_id or not payload:
+                continue
+            try:
+                job = CompactionJob(**json.loads(payload))
+            except Exception:
+                self._logger.exception("compaction: invalid job chat_id=%s", chat_id)
+                client.hdel(_JOBS_KEY, chat_id)
+                continue
+            if job.next_attempt_at > time.time():
+                continue
+            token = uuid4().hex
+            if not client.set(
+                f"{_LOCK_PREFIX}{chat_id}", token, nx=True, ex=_LOCK_TTL_SECONDS
+            ):
+                continue
+            try:
+                self._process(client, job)
+                client.hdel(_JOBS_KEY, chat_id)
+                processed += 1
+            except Exception as error:
+                self._retry_or_refund(client, job, error)
+            finally:
+                lock_key = f"{_LOCK_PREFIX}{chat_id}"
+                if self._text(client.get(lock_key)) == token:
+                    client.delete(lock_key)
+        return processed
+
+    def _process(self, client: Any, job: CompactionJob) -> None:
+        current_summary = self._get_summary(client, job.chat_id)
+        current_marker = self._get_marker(client, job.chat_id) if current_summary else None
+        if (
+            job.result_summary
+            and current_summary == job.result_summary
+            and current_marker == job.target_marker
+        ):
+            # The process stopped after saving memory but before deleting the
+            # durable job. Finish its billing instead of refunding it.
+            self._settle(job)
+            return
+        if current_summary != job.prior_summary or current_marker != job.expected_marker:
+            self._refund(job, reason="memory_compaction_obsolete")
+            return
+
+        if not job.result_summary:
+            summary, cost = self._compact(job.messages, job.prior_summary)
+            if not summary or cost <= 0:
+                raise RuntimeError("summary provider did not produce billable output")
+            job.result_summary = summary
+            job.result_cost_usd_micros = cost
+            client.hset(
+                _JOBS_KEY,
+                job.chat_id,
+                json.dumps(asdict(job), ensure_ascii=False),
+            )
+
+        self._save_result(
+            client,
+            job.chat_id,
+            job.result_summary,
+            job.target_marker,
+        )
+        self._settle(job)
+        self._logger.info(
+            "compaction: completed chat_id=%s target=%s attempts=%d cost_usd_micros=%d",
+            job.chat_id,
+            job.target_marker,
+            job.attempts + 1,
+            job.result_cost_usd_micros,
+        )
+
+    def _retry_or_refund(self, client: Any, job: CompactionJob, error: Exception) -> None:
+        job.attempts += 1
+        self._logger.warning(
+            "compaction: attempt failed chat_id=%s attempt=%d/%d error=%s",
+            job.chat_id,
+            job.attempts,
+            _MAX_ATTEMPTS,
+            error,
+        )
+        if job.attempts >= _MAX_ATTEMPTS:
+            self._refund(job, reason="memory_compaction_failed")
+            client.hdel(_JOBS_KEY, job.chat_id)
+            return
+        job.next_attempt_at = time.time() + 30 * (2 ** (job.attempts - 1))
+        client.hset(
+            _JOBS_KEY,
+            job.chat_id,
+            json.dumps(asdict(job), ensure_ascii=False),
+        )
+
+    def _settle(self, job: CompactionJob) -> None:
+        reserved = int(job.reservation.get("reserved_credit_units") or 0)
+        actual = credit_units_from_usd_micros(job.result_cost_usd_micros)
+        if actual < reserved:
+            self._refund(job, amount=reserved - actual, reason="memory_compaction_success")
+        elif actual > reserved:
+            self._credits.charge_ai_credits(
+                user_id=job.user_id,
+                chat_id=job.reservation.get("chat_scope_id"),
+                amount=actual - reserved,
+                event_type="ai_settlement_charge",
+                metadata={"usage_tag": job.reservation.get("usage_tag")},
+            )
+
+    def _refund(
+        self,
+        job: CompactionJob,
+        *,
+        reason: str,
+        amount: int | None = None,
+    ) -> None:
+        refund_amount = (
+            int(job.reservation.get("reserved_credit_units") or 0)
+            if amount is None
+            else max(0, int(amount))
+        )
+        if refund_amount <= 0:
+            return
+        self._credits.refund_ai_charge(
+            user_id=job.user_id,
+            chat_id=job.reservation.get("chat_scope_id"),
+            amount=refund_amount,
+            source=str(job.reservation.get("source") or "user"),
+            event_type="ai_refund",
+            metadata={
+                "usage_tag": job.reservation.get("usage_tag"),
+                "reason": reason,
+                "message_id": job.message_id,
+            },
+        )
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.run_pending_once()
+            except Exception as error:
+                self._logger.warning("compaction: worker poll failed: %s", error)
+            self._stop.wait(_POLL_SECONDS)
+
+    @staticmethod
+    def _text(value: Any) -> str:
+        if isinstance(value, bytes):
+            return value.decode("utf-8", errors="replace")
+        return str(value or "")

--- a/api/memory/compaction.py
+++ b/api/memory/compaction.py
@@ -15,6 +15,17 @@ class IncrementalSummarySource:
     next_marker: str | None
 
 
+@dataclass(frozen=True)
+class CompactionPlan:
+    """A durable unit of compaction work that can run after the answer."""
+
+    chat_id: str
+    messages: list[dict[str, Any]]
+    prior_summary: str | None
+    expected_marker: str | None
+    target_marker: str
+
+
 def build_incremental_summary_source(
     history: list[dict[str, Any]],
     existing_summary: str | None,
@@ -110,14 +121,14 @@ def prepare_chat_memory(
     get_summary: Callable[[redis.Redis, str], str | None],
     get_marker: Callable[[redis.Redis, str], str | None],
     fetch_full_history: Callable[..., list[dict[str, Any]]],
-    compact_memory: Callable[..., tuple[
-        str | None,
-        list[dict[str, Any]],
-        str | None,
-        int,
-    ]],
     search_history: Callable[..., list[dict[str, Any]]],
-) -> tuple[list[dict[str, Any]], str | None, list[dict[str, Any]], int]:
+) -> tuple[
+    list[dict[str, Any]],
+    str | None,
+    list[dict[str, Any]],
+    int,
+    CompactionPlan | None,
+]:
     summary = (
         get_summary(redis_client, chat_id)
         if redis_client is not None and chat_id
@@ -137,15 +148,30 @@ def prepare_chat_memory(
         if redis_client is not None and chat_id and summary
         else None
     )
-    summary, visible, _marker, cost = compact_memory(
-        redis_client,
-        chat_id,
-        base_history,
-        summary,
-        marker,
-        compaction_threshold=compaction_threshold,
-        compaction_keep=compaction_keep,
-    )
+    source = build_incremental_summary_source(base_history, summary, marker)
+    visible = source.delta_messages
+    plan = None
+    if (
+        chat_id
+        and not source.is_zero_delta
+        and len(source.delta_messages) > compaction_threshold
+    ):
+        dropped = source.delta_messages[:-compaction_keep]
+        if dropped:
+            target_marker = str(dropped[-1].get("id") or "")
+            if target_marker:
+                plan = CompactionPlan(
+                    chat_id=chat_id,
+                    messages=dropped,
+                    prior_summary=source.prior_summary,
+                    expected_marker=marker,
+                    target_marker=target_marker,
+                )
+                # The first compaction has no summary yet. Keep the full
+                # history in this request so moving work to the background
+                # does not remove context from the current answer.
+                if summary:
+                    visible = source.delta_messages[-compaction_keep:]
     recent_ids = {
         str(message.get("id"))
         for message in visible
@@ -163,4 +189,4 @@ def prepare_chat_memory(
         if redis_client is not None and chat_id and query_text.strip()
         else []
     )
-    return visible, summary, retrieved, cost
+    return visible, summary, retrieved, 0, plan

--- a/api/memory/state.py
+++ b/api/memory/state.py
@@ -239,6 +239,20 @@ def save_chat_compacted_until(redis_client: redis.Redis, chat_id: str, marker: s
     redis_client.setex(_compacted_until_key(chat_id), CHAT_SUMMARY_TTL, marker)
 
 
+def save_chat_compaction_result(
+    redis_client: redis.Redis,
+    chat_id: str,
+    summary: str,
+    marker: str,
+) -> None:
+    """Save a summary and its marker in one Redis transaction."""
+
+    pipeline = redis_client.pipeline(transaction=True)
+    pipeline.setex(_summary_key(chat_id), CHAT_SUMMARY_TTL, summary)
+    pipeline.setex(_compacted_until_key(chat_id), CHAT_SUMMARY_TTL, marker)
+    pipeline.execute()
+
+
 def fetch_chat_messages_for_compaction(
     redis_client: redis.Redis,
     chat_id: str,
@@ -681,6 +695,7 @@ class MessageStateService:
     save_user_chat_compacted_until = staticmethod(save_user_chat_compacted_until)
     get_chat_compacted_until = staticmethod(get_chat_compacted_until)
     save_chat_compacted_until = staticmethod(save_chat_compacted_until)
+    save_chat_compaction_result = staticmethod(save_chat_compaction_result)
     save_chat_member = staticmethod(save_chat_member)
     get_chat_members = staticmethod(get_chat_members)
 
@@ -797,6 +812,7 @@ __all__ = [
     "get_user_chat_compacted_until",
     "get_user_chat_summary",
     "save_chat_compacted_until",
+    "save_chat_compaction_result",
     "save_chat_member",
     "save_chat_summary",
     "save_user_chat_compacted_until",

--- a/api/memory/summary.py
+++ b/api/memory/summary.py
@@ -322,7 +322,7 @@ class SummaryService:
             get_marker=deps.state.get_chat_compacted_until,
             save_result=deps.state.save_chat_compaction_result,
             estimate_reserve=self.estimate_compaction_reserve,
-            credits=deps.credits,
+            settle_reservation=deps.credits.settle_ai_reservation_once,
             logger=deps.logger,
         )
 

--- a/api/memory/summary.py
+++ b/api/memory/summary.py
@@ -13,7 +13,9 @@ from typing import Any
 import redis
 
 from api.memory import compaction as memory_compaction
-from api.memory.compaction import IncrementalSummarySource
+from api.ai.pricing import credit_units_from_usd_micros
+from api.memory.background import DurableCompactionQueue
+from api.memory.compaction import CompactionPlan, IncrementalSummarySource
 
 
 def call_summary_model(
@@ -185,12 +187,7 @@ def stream_summary_command(
     prompt_text: str,
     *,
     get_history: Callable[[str, redis.Redis], list[dict[str, Any]]],
-    prepare_memory: Callable[..., tuple[
-        list[dict[str, Any]],
-        str | None,
-        list[dict[str, Any]],
-        int,
-    ]],
+    prepare_memory: Callable[..., Any],
     load_personality: Callable[[], str],
     build_provider: Callable[[], Any],
     sanitize_text: Callable[[str], str],
@@ -213,14 +210,13 @@ def stream_summary_command(
 
         return empty(), None
 
-    visible_history, summary_text, _retrieved_messages, summary_cost = (
-        prepare_memory(
-            redis_client,
-            chat_id,
-            history,
-            prompt_text,
-        )
+    prepared = prepare_memory(
+        redis_client,
+        chat_id,
+        history,
+        prompt_text,
     )
+    visible_history, summary_text, _retrieved_messages, summary_cost = prepared[:4]
     source = IncrementalSummarySource(
         prior_summary=summary_text,
         delta_messages=visible_history,
@@ -309,6 +305,9 @@ class SummaryServiceDeps:
     truncate_lines: int
     no_markdown_prompt: str
     pricing_by_model: Mapping[str, Mapping[str, int]]
+    redis_factory: Callable[[], Any]
+    credits: Any
+    compaction_timeout_seconds: float
 
 
 class SummaryService:
@@ -316,6 +315,16 @@ class SummaryService:
 
     def __init__(self, deps: SummaryServiceDeps) -> None:
         self._deps = deps
+        self._background = DurableCompactionQueue(
+            redis_factory=deps.redis_factory,
+            compact=self.compact_conversation,
+            get_summary=deps.state.get_chat_summary,
+            get_marker=deps.state.get_chat_compacted_until,
+            save_result=deps.state.save_chat_compaction_result,
+            estimate_reserve=self.estimate_compaction_reserve,
+            credits=deps.credits,
+            logger=deps.logger,
+        )
 
     def estimate_cost(self, input_tokens: int, output_tokens: int, model: str) -> int:
         return estimate_summary_cost_usd_micros(
@@ -331,7 +340,9 @@ class SummaryService:
     ) -> tuple[str | None, int]:
         return call_summary_model(
             messages,
-            get_client=self._deps.provider.get_openrouter_client,
+            get_client=lambda: self._deps.provider.get_openrouter_client(
+                timeout=self._deps.compaction_timeout_seconds
+            ),
             estimate_tokens=self._deps.estimate_tokens,
             estimate_cost=self.estimate_cost,
             model=self._deps.model,
@@ -361,6 +372,31 @@ class SummaryService:
             max_summary_messages=self._deps.max_summary_messages,
             truncate_lines=self._deps.truncate_lines,
         )
+
+    def estimate_compaction_reserve(self, plan: CompactionPlan) -> int:
+        api_messages = build_chat_messages(
+            self.load_personality(),
+            plan.messages,
+            "actualiza el resumen previo con los mensajes nuevos",
+            prior_summary=plan.prior_summary,
+        )
+        input_tokens = self._deps.estimate_tokens(api_messages)
+        cost = self.estimate_cost(input_tokens, self._deps.max_tokens, self._deps.model)
+        return credit_units_from_usd_micros(cost)
+
+    def schedule_compaction(self, plan: CompactionPlan | None, billing: Any) -> bool:
+        if plan is None:
+            return False
+        return self._background.enqueue(plan, billing)
+
+    def start_background_worker(self) -> None:
+        self._background.start()
+
+    def stop_background_worker(self) -> None:
+        self._background.stop()
+
+    def run_pending_compactions_once(self) -> int:
+        return self._background.run_pending_once()
 
     def build_messages(
         self,
@@ -457,7 +493,13 @@ class SummaryService:
         reply_to_message_id: str | None = None,
         compaction_threshold: int | None = None,
         compaction_keep: int | None = None,
-    ) -> tuple[list[dict[str, Any]], str | None, list[dict[str, Any]], int]:
+    ) -> tuple[
+        list[dict[str, Any]],
+        str | None,
+        list[dict[str, Any]],
+        int,
+        CompactionPlan | None,
+    ]:
         """Prepare the smallest useful memory package for the next AI request.
 
         The result separates recent visible history, the compact summary, and
@@ -479,6 +521,5 @@ class SummaryService:
             get_summary=self._deps.state.get_chat_summary,
             get_marker=self._deps.state.get_chat_compacted_until,
             fetch_full_history=self._deps.state.fetch_for_compaction,
-            compact_memory=self.compact_memory,
             search_history=self._deps.state.search_history,
         )

--- a/api/providers/config.py
+++ b/api/providers/config.py
@@ -46,6 +46,7 @@ def build_openrouter_client(
     environment: Mapping[str, str],
     client_factory: Callable[..., Any],
     default_headers: Mapping[str, str] | None = None,
+    timeout: float = 60.0,
 ) -> Any | None:
     api_key = get_api_key()
     base_url = get_base_url()
@@ -58,7 +59,10 @@ def build_openrouter_client(
     kwargs: dict[str, Any] = {
         "api_key": api_key,
         "base_url": base_url,
-        "timeout": 60.0,
+        "timeout": timeout,
+        # ProviderRuntime owns retries. Keeping one retry layer prevents the
+        # SDK and the application from multiplying slow server-tool attempts.
+        "max_retries": 0,
     }
     if headers:
         kwargs["default_headers"] = headers
@@ -111,6 +115,7 @@ def build_web_search_tool(max_results: int, max_queries: int) -> dict[str, Any]:
         "parameters": {
             "engine": "firecrawl",
             "max_results": max_results,
+            "max_uses": max_queries,
             "max_total_results": max_results * max_queries,
         },
     }

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -111,13 +111,18 @@ class OpenRouterProvider(StreamingAIProvider):
 
             if enable_web_search and not extra_tools:
                 self._increment_request_count()
+                web_search_tool = self._build_web_search_tool()
                 request_kwargs = {
                     "model": self._primary_model,
                     "messages": [system_message] + list(messages),
                     "max_tokens": max_tokens if max_tokens is not None else output_token_limit,
                     "stream": True,
-                    "tools": [self._build_web_search_tool()],
+                    "tools": [web_search_tool],
                 }
+                self._runtime._apply_web_search_limits(
+                    request_kwargs,
+                    web_search_tool,
+                )
 
                 has_tool_calls = False
                 for chunk in client.chat.completions.create(**request_kwargs):

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -23,7 +23,11 @@ from api.tools.runtime import ToolRuntime
 
 
 logger = get_logger(__name__)
-_MAX_RETRIES = 5
+_MAX_RETRIES = 2
+_UNGROUNDED_SEARCH_MESSAGE = (
+    "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
+    "resultados citables; probá de nuevo en un momento."
+)
 _PSEUDO_TOOL_CALL_PATTERN = re.compile(
     r'^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\((?P<arguments>.*)\)\s*$',
     re.DOTALL,
@@ -160,7 +164,9 @@ class ProviderRuntime:
 
         tools_list: List[Dict[str, Any]] = []
         if enable_web_search:
-            tools_list.append(self._deps.build_web_search_tool())
+            web_search_tool = self._deps.build_web_search_tool()
+            tools_list.append(web_search_tool)
+            self._apply_web_search_limits(request_kwargs, web_search_tool)
         if extra_tools:
             tools_list.extend(extra_tools)
         if tools_list:
@@ -590,6 +596,7 @@ class ProviderRuntime:
         round_idx: int,
         *,
         metadata: Optional[Dict[str, Any]] = None,
+        text_override: Optional[str] = None,
     ) -> AIUsageResult:
         result_metadata = {
             "provider": "openrouter",
@@ -598,7 +605,11 @@ class ProviderRuntime:
         }
         return self._deps.build_usage_result(
             kind="chat",
-            text=str(getattr(message, "content", "") or ""),
+            text=(
+                text_override
+                if text_override is not None
+                else str(getattr(message, "content", "") or "")
+            ),
             model=self._deps.primary_model,
             response=response,
             metadata=result_metadata,
@@ -648,21 +659,44 @@ class ProviderRuntime:
                 metadata["web_search_requests"] = int(web_search_requests)
             except (TypeError, ValueError):
                 pass
-        if "web_search_requests" in metadata:
-            return metadata
-
         annotations = getattr(message, "annotations", None) or []
-        has_url_citation = any(
+        citation_count = sum(
+            1
+            for annotation in annotations
+            if (
             getattr(annotation, "type", None) == "url_citation"
             or (
                 isinstance(annotation, Mapping)
                 and str(annotation.get("type") or "") == "url_citation"
             )
-            for annotation in annotations
+            )
         )
-        if has_url_citation:
+        metadata["web_search_citation_count"] = citation_count
+        if "web_search_requests" not in metadata and citation_count:
             metadata["web_search_requests"] = 1
+        if int(metadata.get("web_search_requests") or 0) > 0:
+            metadata["web_search_grounded"] = citation_count > 0
         return metadata
+
+    @staticmethod
+    def _web_search_max_uses(tool: Mapping[str, Any]) -> int:
+        parameters = ensure_mapping(tool.get("parameters")) or {}
+        try:
+            return max(0, int(parameters.get("max_uses") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    @classmethod
+    def _apply_web_search_limits(
+        cls,
+        request_kwargs: Dict[str, Any],
+        tool: Mapping[str, Any],
+    ) -> None:
+        max_uses = cls._web_search_max_uses(tool)
+        if max_uses:
+            # OpenRouter applies this cap to all server-tool calls in the
+            # request. It is a second guard in addition to max_uses.
+            request_kwargs["extra_body"] = {"max_tool_calls": max_uses}
 
     def _handle_stop_response(
         self,
@@ -689,13 +723,31 @@ class ProviderRuntime:
             self._deps.increment_request_count()
             return ToolRoundDecision(updated_messages, continue_rounds=True)
 
+        web_metadata = self._web_search_metadata(response, message)
+        text_override = None
+        if web_metadata.get("web_search_grounded") is False:
+            warning_context = dict(tool_context or {})
+            warning_context.update(
+                {
+                    "model": self._deps.primary_model,
+                    "tool_round": round_idx + 1,
+                    **web_metadata,
+                }
+            )
+            logger.warning(
+                "openrouter: suppressing ungrounded web-search answer%s",
+                format_log_context(warning_context),
+            )
+            text_override = _UNGROUNDED_SEARCH_MESSAGE
+
         return ToolRoundDecision(
             current_messages,
             result=self._build_round_result(
                 response,
                 message,
                 round_idx,
-                metadata=self._web_search_metadata(response, message),
+                metadata=web_metadata,
+                text_override=text_override,
             ),
         )
 

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -568,12 +568,13 @@ class ProviderRuntime:
             if round_response is None:
                 return None
             response, choice = round_response
+            message = choice.message
             remaining_web_search_uses = self._remaining_web_search_uses(
                 remaining_web_search_uses,
                 response,
+                message,
             )
             finish_reason = choice.finish_reason
-            message = choice.message
 
             if finish_reason == "tool_calls":
                 decision = self._handle_stream_structured_calls(
@@ -744,22 +745,42 @@ class ProviderRuntime:
                 max_results * limited,
             )
 
-    def _web_search_request_count(self, response: Any) -> int:
+    def _web_search_request_count(self, response: Any, message: Any = None) -> int:
         usage_map = self._deps.extract_usage_map(response) or {}
         server_tool_use = ensure_mapping(usage_map.get("server_tool_use")) or {}
         try:
-            return max(0, int(server_tool_use.get("web_search_requests") or 0))
+            request_count = max(
+                0,
+                int(server_tool_use.get("web_search_requests") or 0),
+            )
         except (TypeError, ValueError):
-            return 0
+            request_count = 0
+        if request_count:
+            return request_count
+        annotations = getattr(message, "annotations", None) or []
+        if any(
+            getattr(annotation, "type", None) == "url_citation"
+            or (
+                isinstance(annotation, Mapping)
+                and str(annotation.get("type") or "") == "url_citation"
+            )
+            for annotation in annotations
+        ):
+            return 1
+        return 0
 
     def _remaining_web_search_uses(
         self,
         remaining: Optional[int],
         response: Any,
+        message: Any = None,
     ) -> Optional[int]:
         if remaining is None:
             return None
-        return max(0, remaining - self._web_search_request_count(response))
+        return max(
+            0,
+            remaining - self._web_search_request_count(response, message),
+        )
 
     @classmethod
     def _apply_web_search_limits(
@@ -897,14 +918,18 @@ class ProviderRuntime:
             if round_response is None:
                 return None
             response, choice = round_response
-            round_web_search_requests = self._web_search_request_count(response)
+            message = choice.message
+            round_web_search_requests = self._web_search_request_count(
+                response,
+                message,
+            )
             total_web_search_requests += round_web_search_requests
             remaining_web_search_uses = self._remaining_web_search_uses(
                 remaining_web_search_uses,
                 response,
+                message,
             )
             finish_reason = choice.finish_reason
-            message = choice.message
 
             if finish_reason == "tool_calls":
                 decision = self._handle_structured_tool_calls(

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import copy
 import json
 import re
 import time
@@ -154,6 +155,7 @@ class ProviderRuntime:
         extra_tools: Optional[List[Dict[str, Any]]],
         tool_context: Optional[Dict[str, Any]],
         round_idx: int,
+        web_search_max_uses: Optional[int] = None,
     ) -> Optional[Any]:
         """Build request, retry on transient errors, and return the response."""
         request_kwargs: Dict[str, Any] = {
@@ -162,13 +164,12 @@ class ProviderRuntime:
             "max_tokens": chat_output_token_limit(self._deps.primary_model),
         }
 
-        tools_list: List[Dict[str, Any]] = []
-        if enable_web_search:
-            web_search_tool = self._deps.build_web_search_tool()
-            tools_list.append(web_search_tool)
-            self._apply_web_search_limits(request_kwargs, web_search_tool)
-        if extra_tools:
-            tools_list.extend(extra_tools)
+        tools_list = self._build_request_tools(
+            enable_web_search=enable_web_search,
+            extra_tools=extra_tools,
+            web_search_max_uses=web_search_max_uses,
+            request_kwargs=request_kwargs,
+        )
         if tools_list:
             request_kwargs["tools"] = tools_list
 
@@ -386,6 +387,7 @@ class ProviderRuntime:
         extra_tools: Optional[List[Dict[str, Any]]],
         tool_context: Optional[Dict[str, Any]],
         round_idx: int,
+        web_search_max_uses: Optional[int] = None,
     ) -> Optional[tuple[Any, Any]]:
         response = self._run_chat_completion(
             client=client,
@@ -395,6 +397,7 @@ class ProviderRuntime:
             extra_tools=extra_tools,
             tool_context=tool_context,
             round_idx=round_idx,
+            web_search_max_uses=web_search_max_uses,
         )
         choices = getattr(response, "choices", None) if response is not None else None
         return (response, choices[0]) if choices else None
@@ -548,6 +551,9 @@ class ProviderRuntime:
             return None
 
         self._deps.increment_request_count()
+        remaining_web_search_uses = self._configured_web_search_max_uses(
+            enable_web_search
+        )
         for round_idx in range(self._deps.max_tool_rounds):
             round_response = self._run_round_choice(
                 client=client,
@@ -557,10 +563,15 @@ class ProviderRuntime:
                 extra_tools=extra_tools,
                 tool_context=tool_context,
                 round_idx=round_idx,
+                web_search_max_uses=remaining_web_search_uses,
             )
             if round_response is None:
                 return None
-            _response, choice = round_response
+            response, choice = round_response
+            remaining_web_search_uses = self._remaining_web_search_uses(
+                remaining_web_search_uses,
+                response,
+            )
             finish_reason = choice.finish_reason
             message = choice.message
 
@@ -624,6 +635,7 @@ class ProviderRuntime:
         current_messages: List[Dict[str, Any]],
         extra_tools: Optional[List[Dict[str, Any]]],
         tool_context: Optional[Dict[str, Any]],
+        total_web_search_requests: int = 0,
     ) -> ToolRoundDecision:
         tool_calls = getattr(message, "tool_calls", None) or []
         known_calls = (
@@ -634,7 +646,12 @@ class ProviderRuntime:
         if not known_calls:
             text = str(getattr(message, "content", "") or "").strip()
             result = (
-                self._build_round_result(response, message, round_idx)
+                self._build_round_result(
+                    response,
+                    message,
+                    round_idx,
+                    metadata={"web_search_requests": total_web_search_requests},
+                )
                 if text
                 else None
             )
@@ -686,6 +703,64 @@ class ProviderRuntime:
         except (TypeError, ValueError):
             return 0
 
+    def _configured_web_search_max_uses(self, enabled: bool) -> Optional[int]:
+        if not enabled:
+            return 0
+        configured = self._web_search_max_uses(self._deps.build_web_search_tool())
+        return configured or None
+
+    def _build_request_tools(
+        self,
+        *,
+        enable_web_search: bool,
+        extra_tools: Optional[List[Dict[str, Any]]],
+        web_search_max_uses: Optional[int],
+        request_kwargs: Dict[str, Any],
+    ) -> List[Dict[str, Any]]:
+        tools = list(extra_tools or [])
+        if not enable_web_search or web_search_max_uses == 0:
+            return tools
+        web_search_tool = copy.deepcopy(self._deps.build_web_search_tool())
+        if web_search_max_uses is not None:
+            self._limit_web_search_tool(web_search_tool, web_search_max_uses)
+        self._apply_web_search_limits(request_kwargs, web_search_tool)
+        return [web_search_tool, *tools]
+
+    @staticmethod
+    def _limit_web_search_tool(tool: Dict[str, Any], remaining: int) -> None:
+        parameters = tool.get("parameters")
+        if not isinstance(parameters, dict):
+            return
+        limited = max(0, int(remaining))
+        parameters["max_uses"] = limited
+        try:
+            max_results = max(0, int(parameters.get("max_results") or 0))
+            current_total = max(0, int(parameters.get("max_total_results") or 0))
+        except (TypeError, ValueError):
+            return
+        if max_results and current_total:
+            parameters["max_total_results"] = min(
+                current_total,
+                max_results * limited,
+            )
+
+    def _web_search_request_count(self, response: Any) -> int:
+        usage_map = self._deps.extract_usage_map(response) or {}
+        server_tool_use = ensure_mapping(usage_map.get("server_tool_use")) or {}
+        try:
+            return max(0, int(server_tool_use.get("web_search_requests") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _remaining_web_search_uses(
+        self,
+        remaining: Optional[int],
+        response: Any,
+    ) -> Optional[int]:
+        if remaining is None:
+            return None
+        return max(0, remaining - self._web_search_request_count(response))
+
     @classmethod
     def _apply_web_search_limits(
         cls,
@@ -707,6 +782,7 @@ class ProviderRuntime:
         current_messages: List[Dict[str, Any]],
         extra_tools: Optional[List[Dict[str, Any]]],
         tool_context: Optional[Dict[str, Any]],
+        total_web_search_requests: int = 0,
     ) -> ToolRoundDecision:
         pseudo_call = self._parse_pseudo_tool_call(
             str(getattr(message, "content", "") or ""),
@@ -724,6 +800,11 @@ class ProviderRuntime:
             return ToolRoundDecision(updated_messages, continue_rounds=True)
 
         web_metadata = self._web_search_metadata(response, message)
+        if total_web_search_requests > 0:
+            web_metadata["web_search_requests"] = total_web_search_requests
+            web_metadata["web_search_grounded"] = bool(
+                web_metadata.get("web_search_citation_count")
+            )
         text_override = None
         if web_metadata.get("web_search_grounded") is False:
             warning_context = dict(tool_context or {})
@@ -798,6 +879,10 @@ class ProviderRuntime:
             return None
 
         self._deps.increment_request_count()
+        remaining_web_search_uses = self._configured_web_search_max_uses(
+            enable_web_search
+        )
+        total_web_search_requests = 0
         for round_idx in range(self._deps.max_tool_rounds):
             round_response = self._run_round_choice(
                 client=client,
@@ -807,10 +892,17 @@ class ProviderRuntime:
                 extra_tools=extra_tools,
                 tool_context=tool_context,
                 round_idx=round_idx,
+                web_search_max_uses=remaining_web_search_uses,
             )
             if round_response is None:
                 return None
             response, choice = round_response
+            round_web_search_requests = self._web_search_request_count(response)
+            total_web_search_requests += round_web_search_requests
+            remaining_web_search_uses = self._remaining_web_search_uses(
+                remaining_web_search_uses,
+                response,
+            )
             finish_reason = choice.finish_reason
             message = choice.message
 
@@ -822,6 +914,7 @@ class ProviderRuntime:
                     current_messages=current_messages,
                     extra_tools=extra_tools,
                     tool_context=tool_context,
+                    total_web_search_requests=total_web_search_requests,
                 )
                 if decision.result is not None:
                     return decision.result
@@ -838,6 +931,7 @@ class ProviderRuntime:
                     current_messages=current_messages,
                     extra_tools=extra_tools,
                     tool_context=tool_context,
+                    total_web_search_requests=total_web_search_requests,
                 )
                 if decision.continue_rounds:
                     current_messages = decision.messages
@@ -849,7 +943,10 @@ class ProviderRuntime:
                     response,
                     message,
                     round_idx,
-                    metadata={"truncated": True},
+                    metadata={
+                        "truncated": True,
+                        "web_search_requests": total_web_search_requests,
+                    },
                 )
 
             self._report_unexpected_finish(

--- a/api/providers/service.py
+++ b/api/providers/service.py
@@ -119,6 +119,7 @@ class ProviderService:
         self,
         *,
         default_headers: Mapping[str, str] | None = None,
+        timeout: float = 60.0,
     ) -> Any | None:
         return provider_config.build_openrouter_client(
             get_api_key=self.get_openrouter_api_key,
@@ -126,6 +127,7 @@ class ProviderService:
             environment=self.environment,
             client_factory=self.openai_client_factory,
             default_headers=default_headers,
+            timeout=timeout,
         )
 
     def get_groq_client(

--- a/api/services/credits_db.py
+++ b/api/services/credits_db.py
@@ -37,6 +37,7 @@ AI_LEDGER_EVENT_TYPES = (
     "ai_settlement_charge",
     "ai_settlement_debt",
     "ai_settlement_result",
+    "memory_compaction_settlement",
 )
 CREDIT_UNITS_MIGRATION_ADVISORY_LOCK_KEY = 48_610_002
 CREDIT_UNITS_MIGRATION_NAME = "credit_amounts_scaled_to_tenths_v1"
@@ -167,6 +168,12 @@ def ensure_schema() -> None:
                         metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
                         created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
                     )
+                    """)
+                cur.execute("""
+                    CREATE INDEX IF NOT EXISTS
+                        idx_credit_ledger_compaction_usage_tag
+                    ON credit_ledger ((metadata->>'usage_tag'))
+                    WHERE event_type = 'memory_compaction_settlement'
                     """)
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS credit_schema_migrations (
@@ -744,6 +751,101 @@ def refund_ai_charge(
         )
         return {
             "user_balance": int(updated_user_balance),
+            "chat_balance": int(chat_balance),
+        }
+
+    return _run_credit_transaction(operation)
+
+
+def settle_ai_reservation_once(
+    user_id: int,
+    chat_id: Optional[int],
+    source: ScopeType,
+    reserved_credit_units: int,
+    actual_credit_units: int,
+    usage_tag: str,
+    *,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Settle one reservation exactly once in the credits transaction.
+
+    Locking the payer account serializes concurrent attempts. The settlement
+    ledger row is the durable idempotency record, so a worker restart cannot
+    apply the same refund or extra charge twice.
+    """
+
+    reserved = max(0, int(reserved_credit_units or 0))
+    actual = max(0, int(actual_credit_units or 0))
+    normalized_source: ScopeType = "chat" if source == "chat" else "user"
+    metadata_dict = dict(metadata or {})
+
+    if normalized_source == "chat" and chat_id is None:
+        raise CreditsDBError("chat-funded settlement requires chat_id")
+    normalized_chat_id = int(chat_id) if chat_id is not None else None
+
+    def operation(cur: Any) -> Dict[str, Any]:
+        user_balance, chat_balance = _get_user_and_chat_balances_for_update(
+            cur, user_id, chat_id
+        )
+        cur.execute(
+            """
+            SELECT 1
+            FROM credit_ledger
+            WHERE event_type = 'memory_compaction_settlement'
+              AND metadata->>'usage_tag' = %s
+            LIMIT 1
+            """,
+            (str(usage_tag),),
+        )
+        if cur.fetchone() is not None:
+            return {
+                "applied": False,
+                "user_balance": int(user_balance),
+                "chat_balance": int(chat_balance),
+            }
+
+        adjustment = reserved - actual
+        if normalized_source == "chat":
+            assert normalized_chat_id is not None
+            chat_balance += adjustment
+            _set_balance(cur, "chat", normalized_chat_id, chat_balance)
+        else:
+            user_balance += adjustment
+            _set_balance(cur, "user", user_id, user_balance)
+
+        settlement_metadata = {
+            "source": normalized_source,
+            "usage_tag": str(usage_tag),
+            "reserved_credit_units": reserved,
+            "actual_credit_units": actual,
+            "adjustment_credit_units": adjustment,
+            **metadata_dict,
+        }
+        cur.execute(
+            """
+            INSERT INTO credit_ledger (
+                event_type,
+                actor_user_id,
+                user_id,
+                chat_id,
+                amount,
+                metadata
+            )
+            VALUES (%s, %s, %s, %s, %s, %s::jsonb)
+            """,
+            (
+                "memory_compaction_settlement",
+                int(user_id),
+                int(user_id),
+                int(chat_id) if chat_id is not None else None,
+                int(adjustment),
+                json.dumps(settlement_metadata),
+            ),
+        )
+        return {
+            "applied": True,
+            "adjustment_credit_units": int(adjustment),
+            "user_balance": int(user_balance),
             "chat_balance": int(chat_balance),
         }
 

--- a/run_polling.py
+++ b/run_polling.py
@@ -76,6 +76,7 @@ def main() -> int:
     from api.tasks.scheduler import get_scheduler, init_scheduler
 
     threading.Thread(target=_price_refresh_loop, daemon=True).start()
+    index.app_runtime.summary.start_background_worker()
     start_world_cup_goal_monitor(
         WorldCupGoalMonitor(
             list_chat_ids=index.list_world_cup_goal_chat_ids,
@@ -121,8 +122,10 @@ def main() -> int:
         )
     except KeyboardInterrupt:
         print("\nShutting down...")
+        index.app_runtime.summary.stop_background_worker()
         return 0
     except Exception as error:
+        index.app_runtime.summary.stop_background_worker()
         print(f"FATAL: {error}", file=sys.stderr)
         return 1
 

--- a/tests/provider_pipeline_support.py
+++ b/tests/provider_pipeline_support.py
@@ -21,6 +21,7 @@ def _build_provider_runtime(*, client, tool_runtime=None):
                 "parameters": {
                     "engine": "firecrawl",
                     "max_results": 10,
+                    "max_uses": 3,
                     "max_total_results": 30,
                 },
             },

--- a/tests/test_ai_billing_internal.py
+++ b/tests/test_ai_billing_internal.py
@@ -1015,6 +1015,21 @@ def test_creditless_cap_allows_under_limit():
     mock_redis.expire.assert_called_once_with("creditless_cap:-100:42", 3600)
 
 
+def test_background_reservation_does_not_consume_message_cap():
+    mock_redis = MagicMock()
+    billing = _make_group_billing(limit=0, redis_client=mock_redis)
+
+    result, error = billing.reserve_background_ai_credits(
+        "memory_compaction:-100:m1",
+        10,
+    )
+
+    assert error is None
+    assert result is not None
+    assert result["source"] == "chat"
+    mock_redis.incr.assert_not_called()
+
+
 def test_creditless_cap_blocks_over_limit_and_refunds():
     mock_redis = MagicMock()
     mock_redis.incr.return_value = 4  # over limit=3

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -299,7 +299,7 @@ def test_run_conversation_passes_summary_and_retrieval_into_prompt_builder():
     assert build_ai_messages.call_args.kwargs["retrieved_messages"] == [{"text": "old hit"}]
 
 
-def test_run_conversation_bills_summary_compaction_as_billing_segment():
+def test_run_conversation_schedules_compaction_after_answer_settlement():
     from api.ai.service import AIConversationRequest, build_ai_service
     from api.bot.message_handler import PreparedMessage
 
@@ -307,7 +307,9 @@ def test_run_conversation_bills_summary_compaction_as_billing_segment():
     ai_service = build_ai_service(
         credits_db_service=MagicMock(is_configured=MagicMock(return_value=True)),
         get_chat_history=MagicMock(return_value=[]),
-        prepare_chat_memory=MagicMock(return_value=([], "summary abc", [], 1234)),
+        prepare_chat_memory=MagicMock(
+            return_value=([], "summary abc", [], 0, "compaction-plan")
+        ),
         build_ai_messages=MagicMock(return_value=[{"role": "user", "content": "hola"}]),
         check_provider_available=MagicMock(return_value=True),
         has_openrouter_fallback=MagicMock(return_value=False),
@@ -315,6 +317,7 @@ def test_run_conversation_bills_summary_compaction_as_billing_segment():
         handle_ai_response=handle_ai_response,
         estimate_ai_base_reserve_credits=MagicMock(return_value=(1, {})),
         estimate_image_context_reserve_credits=MagicMock(return_value=1),
+        schedule_compaction=(schedule_compaction := MagicMock()),
     )
 
     billing_helper = MagicMock()
@@ -342,7 +345,8 @@ def test_run_conversation_bills_summary_compaction_as_billing_segment():
 
     settle_args = billing_helper.settle_reserved_ai_credits_batch.call_args.args
     billing_segments = settle_args[1]
-    assert any(segment.get("kind") == "summary" for segment in billing_segments)
+    assert not any(segment.get("kind") == "summary" for segment in billing_segments)
+    schedule_compaction.assert_called_once_with("compaction-plan", billing_helper)
 
 
 def test_run_conversation_uses_fallback_metadata_not_response_text():

--- a/tests/test_background_compaction.py
+++ b/tests/test_background_compaction.py
@@ -135,22 +135,33 @@ def test_compaction_skips_reservation_when_a_chat_already_has_a_job():
     billing.reserve_background_ai_credits.assert_not_called()
 
 
-def test_enqueue_race_refunds_without_message_cap_rollback():
+def test_enqueue_race_uses_distinct_settlement_ids_and_refunds_loser():
     from api.memory.compaction import CompactionPlan
 
     redis_client = _FakeRedis()
-    redis_client.hsetnx = MagicMock(return_value=0)
+    redis_client.hexists = MagicMock(return_value=False)
     settle_reservation = MagicMock(return_value={"applied": True})
-    billing = MagicMock(user_id=42, message={"message_id": 99})
-    billing.reserve_background_ai_credits.return_value = (
-        {
-            "reserved_credit_units": 3,
-            "chat_scope_id": 100,
-            "source": "chat",
-            "usage_tag": "memory_compaction:123:m1",
-        },
-        None,
-    )
+
+    def build_billing(message_id):
+        billing = MagicMock(user_id=42, message={"message_id": message_id})
+
+        def reserve(usage_tag, _amount, *, metadata):
+            return (
+                {
+                    "reserved_credit_units": 3,
+                    "chat_scope_id": 100,
+                    "source": "chat",
+                    "usage_tag": usage_tag,
+                    "metadata": metadata,
+                },
+                None,
+            )
+
+        billing.reserve_background_ai_credits.side_effect = reserve
+        return billing
+
+    winner_billing = build_billing(99)
+    loser_billing = build_billing(100)
     queue = _build_queue(
         redis_client,
         compact=MagicMock(),
@@ -158,15 +169,19 @@ def test_enqueue_race_refunds_without_message_cap_rollback():
         settle_reservation=settle_reservation,
     )
 
-    result = queue.enqueue(
-        CompactionPlan("123", [{"id": "m1"}], None, None, "m1"),
-        billing,
-    )
+    plan = CompactionPlan("123", [{"id": "m1"}], None, None, "m1")
+    assert queue.enqueue(plan, winner_billing) is True
+    stored_job = json.loads(redis_client.hgetall("memory:compaction:jobs")["123"])
 
-    assert result is False
+    assert queue.enqueue(plan, loser_billing) is False
+
     settle_reservation.assert_called_once()
     assert settle_reservation.call_args.kwargs["actual_credit_units"] == 0
-    billing.refund_reserved_ai_credits.assert_not_called()
+    loser_usage_tag = settle_reservation.call_args.kwargs["usage_tag"]
+    assert loser_usage_tag != stored_job["reservation"]["usage_tag"]
+    assert loser_usage_tag.startswith("memory_compaction:123:m1:")
+    winner_billing.refund_reserved_ai_credits.assert_not_called()
+    loser_billing.refund_reserved_ai_credits.assert_not_called()
 
 
 def test_incompatible_job_refunds_reservation_before_deletion():
@@ -203,7 +218,7 @@ def test_incompatible_job_refunds_reservation_before_deletion():
     assert redis_client.hgetall("memory:compaction:jobs") == {}
 
 
-def test_undecodable_job_is_retained_for_manual_recovery():
+def test_undecodable_job_is_quarantined_for_manual_recovery():
     redis_client = _FakeRedis()
     redis_client.hset("memory:compaction:jobs", "123", "not-json")
     queue = _build_queue(
@@ -215,4 +230,10 @@ def test_undecodable_job_is_retained_for_manual_recovery():
 
     queue.run_pending_once()
 
-    assert redis_client.hgetall("memory:compaction:jobs")["123"] == "not-json"
+    assert redis_client.hgetall("memory:compaction:jobs") == {}
+    dead_jobs = redis_client.hgetall("memory:compaction:dead_jobs")
+    assert len(dead_jobs) == 1
+    dead_job = json.loads(next(iter(dead_jobs.values())))
+    assert dead_job["chat_id"] == "123"
+    assert dead_job["payload"] == "not-json"
+    assert dead_job["reason"] == "undecodable"

--- a/tests/test_background_compaction.py
+++ b/tests/test_background_compaction.py
@@ -1,3 +1,5 @@
+import json
+
 from tests.support import *
 
 
@@ -39,7 +41,7 @@ class _FakeRedis:
         return int(self.values.pop(key, None) is not None)
 
 
-def _build_queue(redis_client, *, compact, save_result, credits):
+def _build_queue(redis_client, *, compact, save_result, settle_reservation):
     from api.memory.background import DurableCompactionQueue
 
     return DurableCompactionQueue(
@@ -49,7 +51,7 @@ def _build_queue(redis_client, *, compact, save_result, credits):
         get_marker=lambda _client, _chat_id: None,
         save_result=save_result,
         estimate_reserve=lambda _plan: 3,
-        credits=credits,
+        settle_reservation=settle_reservation,
         logger=MagicMock(),
     )
 
@@ -60,12 +62,12 @@ def test_compaction_is_persisted_before_the_model_runs_and_survives_queue_restar
     redis_client = _FakeRedis()
     compact = MagicMock(return_value=("[contexto anterior: resumen]", 100))
     save_result = MagicMock()
-    credits = MagicMock()
+    settle_reservation = MagicMock(return_value={"applied": True})
     billing = MagicMock(
         user_id=42,
         message={"message_id": 99},
     )
-    billing.reserve_ai_credits.return_value = (
+    billing.reserve_background_ai_credits.return_value = (
         {
             "reserved_credit_units": 3,
             "chat_scope_id": None,
@@ -86,7 +88,7 @@ def test_compaction_is_persisted_before_the_model_runs_and_survives_queue_restar
         redis_client,
         compact=compact,
         save_result=save_result,
-        credits=credits,
+        settle_reservation=settle_reservation,
     )
     assert first_process.enqueue(plan, billing) is True
     compact.assert_not_called()
@@ -95,7 +97,7 @@ def test_compaction_is_persisted_before_the_model_runs_and_survives_queue_restar
         redis_client,
         compact=compact,
         save_result=save_result,
-        credits=credits,
+        settle_reservation=settle_reservation,
     )
     assert restarted_process.run_pending_once() == 1
 
@@ -107,7 +109,8 @@ def test_compaction_is_persisted_before_the_model_runs_and_survives_queue_restar
         "m1",
     )
     assert redis_client.hgetall("memory:compaction:jobs") == {}
-    credits.refund_ai_charge.assert_called_once()
+    settle_reservation.assert_called_once()
+    assert settle_reservation.call_args.kwargs["actual_credit_units"] == 1
 
 
 def test_compaction_skips_reservation_when_a_chat_already_has_a_job():
@@ -120,7 +123,7 @@ def test_compaction_skips_reservation_when_a_chat_already_has_a_job():
         redis_client,
         compact=MagicMock(),
         save_result=MagicMock(),
-        credits=MagicMock(),
+        settle_reservation=MagicMock(),
     )
 
     result = queue.enqueue(
@@ -129,4 +132,87 @@ def test_compaction_skips_reservation_when_a_chat_already_has_a_job():
     )
 
     assert result is False
-    billing.reserve_ai_credits.assert_not_called()
+    billing.reserve_background_ai_credits.assert_not_called()
+
+
+def test_enqueue_race_refunds_without_message_cap_rollback():
+    from api.memory.compaction import CompactionPlan
+
+    redis_client = _FakeRedis()
+    redis_client.hsetnx = MagicMock(return_value=0)
+    settle_reservation = MagicMock(return_value={"applied": True})
+    billing = MagicMock(user_id=42, message={"message_id": 99})
+    billing.reserve_background_ai_credits.return_value = (
+        {
+            "reserved_credit_units": 3,
+            "chat_scope_id": 100,
+            "source": "chat",
+            "usage_tag": "memory_compaction:123:m1",
+        },
+        None,
+    )
+    queue = _build_queue(
+        redis_client,
+        compact=MagicMock(),
+        save_result=MagicMock(),
+        settle_reservation=settle_reservation,
+    )
+
+    result = queue.enqueue(
+        CompactionPlan("123", [{"id": "m1"}], None, None, "m1"),
+        billing,
+    )
+
+    assert result is False
+    settle_reservation.assert_called_once()
+    assert settle_reservation.call_args.kwargs["actual_credit_units"] == 0
+    billing.refund_reserved_ai_credits.assert_not_called()
+
+
+def test_incompatible_job_refunds_reservation_before_deletion():
+    redis_client = _FakeRedis()
+    redis_client.hset(
+        "memory:compaction:jobs",
+        "123",
+        json.dumps(
+            {
+                "chat_id": "123",
+                "removed_schema_field": True,
+                "user_id": 42,
+                "reservation": {
+                    "reserved_credit_units": 3,
+                    "chat_scope_id": None,
+                    "source": "user",
+                    "usage_tag": "memory_compaction:123:m1",
+                },
+            }
+        ),
+    )
+    settle_reservation = MagicMock(return_value={"applied": True})
+    queue = _build_queue(
+        redis_client,
+        compact=MagicMock(),
+        save_result=MagicMock(),
+        settle_reservation=settle_reservation,
+    )
+
+    queue.run_pending_once()
+
+    settle_reservation.assert_called_once()
+    assert settle_reservation.call_args.kwargs["actual_credit_units"] == 0
+    assert redis_client.hgetall("memory:compaction:jobs") == {}
+
+
+def test_undecodable_job_is_retained_for_manual_recovery():
+    redis_client = _FakeRedis()
+    redis_client.hset("memory:compaction:jobs", "123", "not-json")
+    queue = _build_queue(
+        redis_client,
+        compact=MagicMock(),
+        save_result=MagicMock(),
+        settle_reservation=MagicMock(),
+    )
+
+    queue.run_pending_once()
+
+    assert redis_client.hgetall("memory:compaction:jobs")["123"] == "not-json"

--- a/tests/test_background_compaction.py
+++ b/tests/test_background_compaction.py
@@ -1,0 +1,132 @@
+from tests.support import *
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.hashes = {}
+        self.values = {}
+
+    def hexists(self, name, field):
+        return field in self.hashes.get(name, {})
+
+    def hsetnx(self, name, field, value):
+        bucket = self.hashes.setdefault(name, {})
+        if field in bucket:
+            return 0
+        bucket[field] = value
+        return 1
+
+    def hset(self, name, field, value):
+        self.hashes.setdefault(name, {})[field] = value
+        return 1
+
+    def hgetall(self, name):
+        return dict(self.hashes.get(name, {}))
+
+    def hdel(self, name, field):
+        return int(self.hashes.get(name, {}).pop(field, None) is not None)
+
+    def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.values:
+            return False
+        self.values[key] = value
+        return True
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def delete(self, key):
+        return int(self.values.pop(key, None) is not None)
+
+
+def _build_queue(redis_client, *, compact, save_result, credits):
+    from api.memory.background import DurableCompactionQueue
+
+    return DurableCompactionQueue(
+        redis_factory=lambda: redis_client,
+        compact=compact,
+        get_summary=lambda _client, _chat_id: None,
+        get_marker=lambda _client, _chat_id: None,
+        save_result=save_result,
+        estimate_reserve=lambda _plan: 3,
+        credits=credits,
+        logger=MagicMock(),
+    )
+
+
+def test_compaction_is_persisted_before_the_model_runs_and_survives_queue_restart():
+    from api.memory.compaction import CompactionPlan
+
+    redis_client = _FakeRedis()
+    compact = MagicMock(return_value=("[contexto anterior: resumen]", 100))
+    save_result = MagicMock()
+    credits = MagicMock()
+    billing = MagicMock(
+        user_id=42,
+        message={"message_id": 99},
+    )
+    billing.reserve_ai_credits.return_value = (
+        {
+            "reserved_credit_units": 3,
+            "chat_scope_id": None,
+            "source": "user",
+            "usage_tag": "memory_compaction:123:m2",
+        },
+        None,
+    )
+    plan = CompactionPlan(
+        chat_id="123",
+        messages=[{"id": "m1", "role": "user", "text": "hola"}],
+        prior_summary=None,
+        expected_marker=None,
+        target_marker="m1",
+    )
+
+    first_process = _build_queue(
+        redis_client,
+        compact=compact,
+        save_result=save_result,
+        credits=credits,
+    )
+    assert first_process.enqueue(plan, billing) is True
+    compact.assert_not_called()
+
+    restarted_process = _build_queue(
+        redis_client,
+        compact=compact,
+        save_result=save_result,
+        credits=credits,
+    )
+    assert restarted_process.run_pending_once() == 1
+
+    compact.assert_called_once_with(plan.messages, None)
+    save_result.assert_called_once_with(
+        redis_client,
+        "123",
+        "[contexto anterior: resumen]",
+        "m1",
+    )
+    assert redis_client.hgetall("memory:compaction:jobs") == {}
+    credits.refund_ai_charge.assert_called_once()
+
+
+def test_compaction_skips_reservation_when_a_chat_already_has_a_job():
+    from api.memory.compaction import CompactionPlan
+
+    redis_client = _FakeRedis()
+    redis_client.hset("memory:compaction:jobs", "123", "{}")
+    billing = MagicMock()
+    queue = _build_queue(
+        redis_client,
+        compact=MagicMock(),
+        save_result=MagicMock(),
+        credits=MagicMock(),
+    )
+
+    result = queue.enqueue(
+        CompactionPlan("123", [], None, None, "m1"),
+        billing,
+    )
+
+    assert result is False
+    billing.reserve_ai_credits.assert_not_called()

--- a/tests/test_credits_db.py
+++ b/tests/test_credits_db.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from api.billing.credit_units import CREDIT_SCALE, whole_credits_to_units
@@ -305,6 +306,65 @@ def test_refund_ai_charge_chat_source_locks_user_before_chat():
 
     assert _locked_accounts(fake_cursor) == [("user", 42), ("chat", 202)]
     assert result == {"user_balance": 11, "chat_balance": 52}
+
+
+def test_settle_ai_reservation_once_is_idempotent():
+    class SettlementCursor(_FakeCursor):
+        def __init__(self):
+            super().__init__(hourly_count=0, daily_count=0, insert_granted=False)
+            self.balance = 10
+            self.settled_usage_tags = set()
+
+        def execute(self, query, params=None):
+            normalized = " ".join(str(query).split())
+            if (
+                "FROM credit_ledger" in normalized
+                and "memory_compaction_settlement" in normalized
+            ):
+                self.fetchone_result = (
+                    (1,) if str(params[0]) in self.settled_usage_tags else None
+                )
+                return
+            if (
+                "INSERT INTO credit_ledger" in normalized
+                and params
+                and params[0] == "memory_compaction_settlement"
+            ):
+                metadata = json.loads(params[5])
+                self.settled_usage_tags.add(metadata["usage_tag"])
+                self.executed.append((normalized, params))
+                self.fetchone_result = None
+                return
+            super().execute(query, params)
+
+    cursor = SettlementCursor()
+    connection = _FakeConnection(cursor)
+    kwargs = {
+        "user_id": 42,
+        "chat_id": None,
+        "source": "user",
+        "reserved_credit_units": 5,
+        "actual_credit_units": 2,
+        "usage_tag": "memory_compaction:123:m1",
+    }
+
+    with (
+        patch("api.services.credits_db.ensure_schema"),
+        patch("api.services.credits_db.connect", return_value=connection),
+    ):
+        first = credits_db.settle_ai_reservation_once(**kwargs)
+        second = credits_db.settle_ai_reservation_once(**kwargs)
+
+    assert first["applied"] is True
+    assert second["applied"] is False
+    assert cursor.balance == 13
+    settlement_rows = [
+        params
+        for query, params in cursor.executed
+        if "INSERT INTO credit_ledger" in query
+        and params[0] == "memory_compaction_settlement"
+    ]
+    assert len(settlement_rows) == 1
 
 
 def test_apply_ai_debt_chat_source_locks_user_before_chat():

--- a/tests/test_memory_compaction.py
+++ b/tests/test_memory_compaction.py
@@ -119,27 +119,20 @@ def test_prepare_chat_memory_uses_searchable_full_history_for_long_gap(monkeypat
         "api.index.app_runtime.state.search_history",
         lambda *_args, **_kwargs: [{"id": "m12", "role": "user", "text": "old hit", "timestamp": 12}],
     )
-    monkeypatch.setattr(
-        "api.index.app_runtime.summary.compact_memory",
-        lambda *_args, **_kwargs: (
-            "summary from full history",
-            full_history[-5:],
-            "m95",
-            1,
-        ),
-    )
-
-    visible_history, summary_text, retrieved_messages, summary_cost = prepare_chat_memory(
+    visible_history, summary_text, retrieved_messages, summary_cost, plan = prepare_chat_memory(
         MagicMock(),
         "123",
         recent_history,
         "que paso hoy",
     )
 
-    assert summary_text == "summary from full history"
-    assert [msg["id"] for msg in visible_history] == ["m96", "m97", "m98", "m99", "m100"]
+    assert summary_text is None
+    assert [msg["id"] for msg in visible_history] == [f"m{i}" for i in range(1, 101)]
     assert retrieved_messages == [{"id": "m12", "role": "user", "text": "old hit", "timestamp": 12}]
-    assert summary_cost == 1
+    assert summary_cost == 0
+    assert plan is not None
+    assert plan.target_marker == "m75"
+    assert [msg["id"] for msg in plan.messages] == [f"m{i}" for i in range(1, 76)]
 
 
 def test_prepare_chat_memory_ignores_marker_without_internal_summary(monkeypatch):
@@ -149,20 +142,6 @@ def test_prepare_chat_memory_ignores_marker_without_internal_summary(monkeypatch
         {"id": f"m{i}", "role": "user", "text": f"msg {i}", "timestamp": i}
         for i in range(1, 101)
     ]
-    captured = {}
-
-    def fake_compact_chat_memory(
-        _redis_client,
-        _chat_id,
-        messages,
-        existing_summary,
-        compacted_until,
-        **_kwargs,
-    ):
-        captured["existing_summary"] = existing_summary
-        captured["compacted_until"] = compacted_until
-        return existing_summary, messages, compacted_until, 0
-
     monkeypatch.setattr("api.index.app_runtime.state.get_chat_summary", lambda *_: None)
     monkeypatch.setattr("api.index.app_runtime.state.get_chat_compacted_until", lambda *_: "m80")
     monkeypatch.setattr(
@@ -170,12 +149,12 @@ def test_prepare_chat_memory_ignores_marker_without_internal_summary(monkeypatch
         lambda *_args, **_kwargs: chat_history,
     )
     monkeypatch.setattr("api.index.app_runtime.state.search_history", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr("api.index.app_runtime.summary.compact_memory", fake_compact_chat_memory)
+    prepared = prepare_chat_memory(MagicMock(), "123", chat_history, "que paso")
 
-    prepare_chat_memory(MagicMock(), "123", chat_history, "que paso")
-
-    assert captured["existing_summary"] is None
-    assert captured["compacted_until"] is None
+    plan = prepared[4]
+    assert plan is not None
+    assert plan.expected_marker is None
+    assert plan.prior_summary is None
 
 
 def test_stream_summary_command_uses_internal_chat_memory(monkeypatch):

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -22,6 +22,7 @@ def test_openrouter_client_uses_explicit_timeout(monkeypatch):
 
     assert client is not None
     assert captured_kwargs["timeout"] == 60.0
+    assert captured_kwargs["max_retries"] == 0
 
 
 def test_strip_markdown_formatting_removes_bold_markers():
@@ -166,10 +167,14 @@ def test_provider_runtime_enables_firecrawl_web_search():
             "parameters": {
                 "engine": "firecrawl",
                 "max_results": 10,
+                "max_uses": 3,
                 "max_total_results": 30,
             },
         }
     ]
+    assert client.chat.completions.create.call_args.kwargs["extra_body"] == {
+        "max_tool_calls": 3
+    }
 
 
 def test_provider_runtime_ignores_invalid_web_search_requests():
@@ -220,6 +225,31 @@ def test_provider_runtime_server_tool_use_takes_priority():
 
     assert result is not None
     assert result.metadata["web_search_requests"] == 3
+
+
+def test_provider_runtime_suppresses_web_search_answer_without_citations():
+    response = _build_chat_response(
+        text="seguro existe esa marca",
+        usage={
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "server_tool_use": {"web_search_requests": 1},
+        },
+    )
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    runtime = _build_provider_runtime(client=client)
+
+    result = runtime.complete(
+        {"role": "system", "content": "sys"},
+        [{"role": "user", "content": "busca la marca Oaaa"}],
+        enable_web_search=True,
+    )
+
+    assert result is not None
+    assert "No pude verificar eso con fuentes" in result.text
+    assert result.metadata["web_search_grounded"] is False
+    assert result.metadata["web_search_citation_count"] == 0
 
 
 def test_provider_runtime_detects_pydantic_annotation():
@@ -275,10 +305,14 @@ def test_provider_runtime_sets_explicit_web_search_limits():
             "parameters": {
                 "engine": "firecrawl",
                 "max_results": 10,
+                "max_uses": 3,
                 "max_total_results": 30,
             },
         }
     ]
+    assert client.chat.completions.create.call_args.kwargs["extra_body"] == {
+        "max_tool_calls": 3
+    }
 
 
 def test_provider_runtime_includes_web_search_by_default():

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -103,6 +103,87 @@ def test_provider_runtime_executes_tool_calls_until_stop():
     assert client.calls[1]["messages"][-1]["role"] == "tool"
 
 
+def test_provider_runtime_shares_web_search_budget_across_tool_rounds():
+    from api.ai.pricing import AIUsageResult
+    from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps
+    from api.tools.runtime import ToolRuntime
+
+    tool_calls = [
+        SimpleNamespace(
+            id="call_1",
+            function=SimpleNamespace(name="calc", arguments='{"x": 1}'),
+        )
+    ]
+    first_response = _FakeResponse(
+        [
+            _FakeChoice(
+                "tool_calls",
+                SimpleNamespace(content="", tool_calls=tool_calls, annotations=[]),
+            )
+        ]
+    )
+    first_response.usage = {"server_tool_use": {"web_search_requests": 2}}
+    second_response = _FakeResponse(
+        [
+            _FakeChoice(
+                "stop",
+                SimpleNamespace(
+                    content="done",
+                    tool_calls=[],
+                    annotations=[{"type": "url_citation"}],
+                ),
+            )
+        ]
+    )
+    second_response.usage = {"server_tool_use": {"web_search_requests": 1}}
+    client = _FakeClient([first_response, second_response])
+    runtime = ProviderRuntime(
+        ProviderRuntimeDeps(
+            get_client=lambda: client,
+            admin_report=MagicMock(),
+            increment_request_count=MagicMock(),
+            build_web_search_tool=lambda: {
+                "type": "openrouter:web_search",
+                "parameters": {
+                    "engine": "firecrawl",
+                    "max_results": 10,
+                    "max_uses": 3,
+                    "max_total_results": 30,
+                },
+            },
+            build_usage_result=lambda **kwargs: AIUsageResult(
+                kind=kwargs["kind"],
+                text=kwargs["text"],
+                model=kwargs["model"],
+                usage={},
+                metadata=kwargs.get("metadata") or {},
+            ),
+            extract_usage_map=lambda response: response.usage,
+            primary_model="test-model",
+            max_tool_rounds=5,
+        ),
+        ToolRuntime(
+            execute_tool_fn=MagicMock(return_value=SimpleNamespace(output="2")),
+            parse_tool_call_arguments_fn=lambda args: json.loads(args),
+            tool_registry={"calc": object()},
+            print_fn=lambda *_args: None,
+        ),
+    )
+
+    result = runtime.complete(
+        {"role": "system", "content": "sys"},
+        [{"role": "user", "content": "search and calculate"}],
+        enable_web_search=True,
+        extra_tools=[{"type": "function", "function": {"name": "calc"}}],
+    )
+
+    assert result is not None
+    assert result.metadata["web_search_requests"] == 3
+    assert client.calls[0]["tools"][0]["parameters"]["max_uses"] == 3
+    assert client.calls[1]["tools"][0]["parameters"]["max_uses"] == 1
+    assert client.calls[1]["extra_body"] == {"max_tool_calls": 1}
+
+
 def test_provider_runtime_returns_text_when_tool_calls_are_unknown():
     from api.ai.pricing import AIUsageResult
     from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -103,7 +103,19 @@ def test_provider_runtime_executes_tool_calls_until_stop():
     assert client.calls[1]["messages"][-1]["role"] == "tool"
 
 
-def test_provider_runtime_shares_web_search_budget_across_tool_rounds():
+@pytest.mark.parametrize(
+    ("first_usage", "first_annotations", "second_max_uses", "total_requests"),
+    [
+        ({"server_tool_use": {"web_search_requests": 2}}, [], 1, 3),
+        ({}, [{"type": "url_citation"}], 2, 2),
+    ],
+)
+def test_provider_runtime_shares_web_search_budget_across_tool_rounds(
+    first_usage,
+    first_annotations,
+    second_max_uses,
+    total_requests,
+):
     from api.ai.pricing import AIUsageResult
     from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps
     from api.tools.runtime import ToolRuntime
@@ -118,11 +130,15 @@ def test_provider_runtime_shares_web_search_budget_across_tool_rounds():
         [
             _FakeChoice(
                 "tool_calls",
-                SimpleNamespace(content="", tool_calls=tool_calls, annotations=[]),
+                SimpleNamespace(
+                    content="",
+                    tool_calls=tool_calls,
+                    annotations=first_annotations,
+                ),
             )
         ]
     )
-    first_response.usage = {"server_tool_use": {"web_search_requests": 2}}
+    first_response.usage = first_usage
     second_response = _FakeResponse(
         [
             _FakeChoice(
@@ -178,10 +194,15 @@ def test_provider_runtime_shares_web_search_budget_across_tool_rounds():
     )
 
     assert result is not None
-    assert result.metadata["web_search_requests"] == 3
+    assert result.metadata["web_search_requests"] == total_requests
     assert client.calls[0]["tools"][0]["parameters"]["max_uses"] == 3
-    assert client.calls[1]["tools"][0]["parameters"]["max_uses"] == 1
-    assert client.calls[1]["extra_body"] == {"max_tool_calls": 1}
+    assert (
+        client.calls[1]["tools"][0]["parameters"]["max_uses"]
+        == second_max_uses
+    )
+    assert client.calls[1]["extra_body"] == {
+        "max_tool_calls": second_max_uses
+    }
 
 
 def test_provider_runtime_returns_text_when_tool_calls_are_unknown():

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -901,9 +901,9 @@ def test_provider_runtime_reports_null_finish_reason_after_retries_exhausted():
         )
 
     assert result is None
-    assert len(client.calls) == 5
-    assert request_count.call_count == 5
-    assert [call.args[0] for call in sleep.call_args_list] == [1, 2, 4, 8]
+    assert len(client.calls) == 2
+    assert request_count.call_count == 2
+    assert [call.args[0] for call in sleep.call_args_list] == [1]
     admin_report.assert_called_once()
     assert admin_report.call_args.args[0] == "OpenRouter unexpected finish_reason=None"
     report_context = admin_report.call_args.kwargs["extra_context"]
@@ -911,8 +911,8 @@ def test_provider_runtime_reports_null_finish_reason_after_retries_exhausted():
         "model": "~deepseek/deepseek-v4-flash-latest",
         "enable_web_search": True,
         "tool_round": 1,
-        "response_id": "gen-4",
-        "request_id": "req-4",
+        "response_id": "gen-1",
+        "request_id": "req-1",
         "response_model": "upstream-model",
         "provider": "upstream-provider",
         "native_finish_reason": "upstream_null",
@@ -1024,7 +1024,7 @@ def test_provider_runtime_keeps_tools_when_json_decode_retries_exhausted():
         )
 
     assert result is None
-    assert len(client.calls) == 5
+    assert len(client.calls) == 2
     assert all("tools" in call for call in client.calls)
     admin_report.assert_called_once()
     assert admin_report.call_args.args[2]["provider_error_body"] == (


### PR DESCRIPTION
## What changed

- Keep Firecrawl enabled and add explicit `max_uses`, result, and total-result limits.
- Set OpenRouter's request-level `max_tool_calls` cap.
- Make the application the only retry owner and limit transient calls to one retry.
- Record search request, citation, and grounding metadata.
- Suppress unsupported search conclusions when a search returns no URL citations.
- Remove model-based conversation compaction from the answer path.
- Reserve the request payer's credits before persisting a compaction job.
- Process durable Redis jobs in a background worker with restart recovery, retries, atomic summary state writes, settlement, and refunds.
- Give background compaction a separate 10-minute provider timeout.

## Why

OpenRouter logs showed two independent latency failures. Synchronous compaction delayed one request by about 4.5 minutes, and OpenRouter server-tool orchestration delayed the search request by about 5 minutes. Nested SDK and application retries could also multiply failures. The old flow made users wait for maintenance work and could return an invented conclusion after a failed search.

## Impact

Normal answers no longer wait for a summary model call. Firecrawl remains available with bounded use. Failed or uncited searches now fail transparently. Compaction only runs after a user or chat credit reservation succeeds, and persisted jobs survive process restarts.

## Verification

- `ruff check api tests run_polling.py`
- `python -m compileall -q api run_polling.py`
- `pytest -q`: 878 passed