### PR TITLE
Add tool-aware streaming and usage billing

### DIFF
--- a/api/ai/request_runtime.py
+++ b/api/ai/request_runtime.py
@@ -176,10 +176,10 @@ def ask_ai(
     timezone_offset: int,
     task_mode: bool,
     build_request: Callable[..., tuple[
-        dict[str, Any],
-        list[dict[str, Any]],
-        list[dict[str, Any]] | None,
-        dict[str, Any],
+            dict[str, Any],
+            list[dict[str, Any]],
+            list[dict[str, Any]] | None,
+            dict[str, Any],
     ]],
     inject_image: Callable[..., None],
     complete: Callable[..., str | None],
@@ -245,11 +245,12 @@ def ask_ai_stream(
     user_name: str | None,
     user_id: int | None,
     timezone_offset: int,
+    response_meta: dict[str, Any] | None,
     build_request: Callable[..., tuple[
-        dict[str, Any],
-        list[dict[str, Any]],
-        list[dict[str, Any]] | None,
-        dict[str, Any],
+            dict[str, Any],
+            list[dict[str, Any]],
+            list[dict[str, Any]] | None,
+            dict[str, Any],
     ]],
     stream: Callable[..., Iterator[tuple[str, str]]],
 ) -> Iterator[tuple[str, str]]:
@@ -262,12 +263,17 @@ def ask_ai_stream(
         task_mode=False,
         enable_web_search=enable_web_search,
     )
+    stream_kwargs: dict[str, Any] = {
+        "enable_web_search": enable_web_search,
+        "extra_tools": extra_tools,
+        "tool_context": tool_context,
+    }
+    if response_meta is not None:
+        stream_kwargs["response_meta"] = response_meta
     return stream(
         system_message,
         messages,
-        enable_web_search=enable_web_search,
-        extra_tools=extra_tools,
-        tool_context=tool_context,
+        **stream_kwargs,
     )
 
 
@@ -412,6 +418,7 @@ class AIRequestService:
         user_name: str | None = None,
         user_id: int | None = None,
         timezone_offset: int = -3,
+        response_meta: dict[str, Any] | None = None,
     ) -> Iterator[tuple[str, str]]:
         return ask_ai_stream(
             messages,
@@ -420,6 +427,7 @@ class AIRequestService:
             user_name=user_name,
             user_id=user_id,
             timezone_offset=timezone_offset,
+            response_meta=response_meta,
             build_request=self.build_request,
             stream=self._deps.stream,
         )

--- a/api/bot/responses.py
+++ b/api/bot/responses.py
@@ -184,6 +184,7 @@ def handle_ai_stream_response(
         user_name=user_name,
         user_id=user_id,
         timezone_offset=timezone_offset,
+        response_meta=response_meta,
     )
     try:
         # The consumer creates one Telegram message, then edits it as tokens arrive.

--- a/api/bot/responses.py
+++ b/api/bot/responses.py
@@ -195,7 +195,18 @@ def handle_ai_stream_response(
             edit_stream_message,
             reply_to_message_id=reply_to_message_id,
         )
+        text_override = (
+            response_meta.pop("stream_text_override", None)
+            if response_meta is not None
+            else None
+        )
+        if isinstance(text_override, str) and text_override.strip():
+            final_text = text_override
+            edit_stream_message(chat_id, final_text, str(message_id))
+            set_stream_metadata(str(message_id), final_text)
     except RuntimeError:
+        if response_meta is not None:
+            response_meta.pop("stream_text_override", None)
         # Telegram editing can fail. Generate the same answer normally and send it
         # as one message so the user still receives a response.
         final_text = ask_ai(

--- a/api/providers/base.py
+++ b/api/providers/base.py
@@ -5,7 +5,7 @@ with support for both completion and streaming modes.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, Iterator, List, Optional, Protocol, Tuple, runtime_checkable
+from typing import Any, Callable, Dict, Iterator, List, Optional, Protocol, Tuple, runtime_checkable
 
 from api.ai.pricing import AIUsageResult
 
@@ -46,6 +46,7 @@ class StreamingAIProvider(AIProvider, Protocol):
         enable_web_search: bool = True,
         extra_tools: Optional[List[Dict[str, Any]]] = None,
         tool_context: Optional[Dict[str, Any]] = None,
+        on_usage_result: Optional[Callable[[AIUsageResult], None]] = None,
     ) -> Iterator[str]:
         """Stream response tokens."""
         ...
@@ -119,6 +120,7 @@ class ProviderChain:
         enable_web_search: bool = True,
         extra_tools: Optional[List[Dict[str, Any]]] = None,
         tool_context: Optional[Dict[str, Any]] = None,
+        on_usage_result: Optional[Callable[[AIUsageResult], None]] = None,
     ) -> Iterator[Tuple[str, str]]:
         """Stream from the first available provider.
 
@@ -129,12 +131,17 @@ class ProviderChain:
             try:
                 if not isinstance(provider, StreamingAIProvider):
                     continue
+                stream_kwargs: Dict[str, Any] = {
+                    "enable_web_search": enable_web_search,
+                    "extra_tools": extra_tools,
+                    "tool_context": tool_context,
+                }
+                if on_usage_result is not None:
+                    stream_kwargs["on_usage_result"] = on_usage_result
                 token_iterator = provider.stream(
                     system_message,
                     messages,
-                    enable_web_search=enable_web_search,
-                    extra_tools=extra_tools,
-                    tool_context=tool_context,
+                    **stream_kwargs,
                 )
                 try:
                     first_token = next(token_iterator)

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -2,12 +2,56 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Iterator, List, Optional
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any, Callable, Dict, Generator, Iterator, List, Optional
 
 from api.ai.pricing import AIUsageResult, chat_output_token_limit
 from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps
 from api.tools.runtime import ToolRuntime
 from api.providers.base import StreamingAIProvider
+
+
+@dataclass
+class _StreamToolCall:
+    index: int
+    id: str = ""
+    type: str = "function"
+    name: str = ""
+    arguments: str = ""
+
+    def as_message_value(self) -> Any:
+        return SimpleNamespace(
+            id=self.id,
+            type=self.type,
+            function=SimpleNamespace(
+                name=self.name,
+                arguments=self.arguments,
+            ),
+        )
+
+
+@dataclass
+class _StreamRound:
+    text_parts: list[str] = field(default_factory=list)
+    annotations: list[Any] = field(default_factory=list)
+    tool_calls: dict[int, _StreamToolCall] = field(default_factory=dict)
+    finish_reason: Any = None
+    usage_response: Any = None
+    last_response: Any = None
+
+    @property
+    def text(self) -> str:
+        return "".join(self.text_parts)
+
+    def message(self) -> Any:
+        calls = [item.as_message_value() for _, item in sorted(self.tool_calls.items())]
+        return SimpleNamespace(
+            content=self.text,
+            annotations=self.annotations,
+            tool_calls=calls,
+        )
 
 
 class OpenRouterProvider(StreamingAIProvider):
@@ -83,92 +127,101 @@ class OpenRouterProvider(StreamingAIProvider):
         extra_tools: Optional[List[Dict[str, Any]]] = None,
         tool_context: Optional[Dict[str, Any]] = None,
         max_tokens: Optional[int] = None,
+        on_usage_result: Optional[Callable[[AIUsageResult], None]] = None,
     ) -> Iterator[str]:
         client = self._get_client()
         if client is None:
             return
 
-        has_tools = bool(extra_tools) or enable_web_search
         output_token_limit = chat_output_token_limit(self._primary_model)
+        current_messages = list(messages)
+        remaining_web_search_uses = self._runtime._configured_web_search_max_uses(enable_web_search)
+        possible_pseudo_tools = self._extra_tool_names(extra_tools)
 
         try:
-            if not has_tools:
+            for round_idx in range(self._max_tool_rounds):
                 self._increment_request_count()
-                request_kwargs: Dict[str, Any] = {
-                    "model": self._primary_model,
-                    "messages": [system_message] + list(messages),
-                    "max_tokens": max_tokens if max_tokens is not None else output_token_limit,
-                    "stream": True,
-                }
-
-                for chunk in client.chat.completions.create(**request_kwargs):
-                    if not chunk.choices:
-                        continue
-                    delta = chunk.choices[0].delta
-                    if delta and delta.content:
-                        yield delta.content
-                return
-
-            if enable_web_search and not extra_tools:
-                self._increment_request_count()
-                web_search_tool = self._build_web_search_tool()
-                request_kwargs = {
-                    "model": self._primary_model,
-                    "messages": [system_message] + list(messages),
-                    "max_tokens": max_tokens if max_tokens is not None else output_token_limit,
-                    "stream": True,
-                    "tools": [web_search_tool],
-                }
-                self._runtime._apply_web_search_limits(
-                    request_kwargs,
-                    web_search_tool,
+                request_kwargs = self._build_stream_request(
+                    system_message,
+                    current_messages,
+                    output_token_limit=output_token_limit,
+                    max_tokens=max_tokens,
+                    enable_web_search=enable_web_search,
+                    extra_tools=extra_tools,
+                    web_search_max_uses=remaining_web_search_uses,
+                )
+                streamed_round, held_text, text_released = yield from (
+                    self._consume_stream_round(
+                        client,
+                        request_kwargs,
+                        possible_pseudo_tools,
+                    )
                 )
 
-                has_tool_calls = False
-                for chunk in client.chat.completions.create(**request_kwargs):
-                    if not chunk.choices:
-                        continue
-                    choice = chunk.choices[0]
-                    delta = choice.delta
-                    if getattr(choice, "finish_reason", None) == "tool_calls":
-                        has_tool_calls = True
-                        break
-                    if delta and delta.content:
-                        yield delta.content
-                if has_tool_calls:
-                    final_messages = self._runtime._execute_tool_rounds(
-                        current_messages=list(messages),
-                        system_message=system_message,
-                        enable_web_search=enable_web_search,
-                        extra_tools=extra_tools,
-                        tool_context=tool_context,
+                message = streamed_round.message()
+                usage_response = (
+                    streamed_round.usage_response
+                    or streamed_round.last_response
+                    or SimpleNamespace(usage={})
+                )
+                web_metadata = self._runtime._web_search_metadata(
+                    usage_response,
+                    message,
+                )
+                if on_usage_result is not None:
+                    on_usage_result(
+                        self._runtime._build_round_result(
+                            usage_response,
+                            message,
+                            round_idx,
+                            metadata=web_metadata,
+                        )
                     )
-                    if final_messages is None:
-                        return
-                    self._increment_request_count()
-                    request_kwargs = {
-                        "model": self._primary_model,
-                        "messages": [system_message] + final_messages,
-                        "max_tokens": max_tokens if max_tokens is not None else output_token_limit,
-                        "stream": True,
-                    }
-                    for chunk in client.chat.completions.create(**request_kwargs):
-                        if not chunk.choices:
-                            continue
-                        delta = chunk.choices[0].delta
-                        if delta and delta.content:
-                            yield delta.content
-                return
+                remaining_web_search_uses = self._runtime._remaining_web_search_uses(
+                    remaining_web_search_uses,
+                    usage_response,
+                    message,
+                )
 
-            result = self._runtime.complete(
-                system_message,
-                list(messages),
-                enable_web_search=enable_web_search,
-                extra_tools=extra_tools,
-                tool_context=tool_context,
-            )
-            if result and result.text:
-                yield result.text
+                tool_calls = getattr(message, "tool_calls", None) or []
+                known_calls = self._runtime._filter_known_calls(
+                    tool_calls,
+                    tool_context,
+                    round_idx,
+                )
+                if known_calls:
+                    if held_text:
+                        yield held_text
+                    current_messages = self._tool_runtime.apply_tool_calls(
+                        message,
+                        known_calls,
+                        current_messages,
+                        tool_context or {},
+                    )
+                    continue
+
+                pseudo_call = self._runtime._parse_pseudo_tool_call(
+                    streamed_round.text,
+                    round_idx,
+                    extra_tools,
+                )
+                if pseudo_call is not None and not text_released:
+                    current_messages = self._tool_runtime.apply_tool_calls(
+                        SimpleNamespace(content=""),
+                        [pseudo_call],
+                        current_messages,
+                        tool_context or {},
+                    )
+                    continue
+
+                if held_text:
+                    yield held_text
+
+                if streamed_round.finish_reason in {"stop", "length", None}:
+                    return
+
+                return
+            return
         except Exception as error:
             self._admin_report(
                 f"OpenRouter stream error model={self._primary_model}",
@@ -176,3 +229,135 @@ class OpenRouterProvider(StreamingAIProvider):
                 {"model": self._primary_model},
             )
             raise
+
+    def _build_stream_request(
+        self,
+        system_message: Dict[str, Any],
+        messages: List[Dict[str, Any]],
+        *,
+        output_token_limit: int,
+        max_tokens: Optional[int],
+        enable_web_search: bool,
+        extra_tools: Optional[List[Dict[str, Any]]],
+        web_search_max_uses: Optional[int],
+    ) -> Dict[str, Any]:
+        request_kwargs: Dict[str, Any] = {
+            "model": self._primary_model,
+            "messages": [system_message] + messages,
+            "max_tokens": (max_tokens if max_tokens is not None else output_token_limit),
+            "stream": True,
+        }
+        request_tools = self._runtime._build_request_tools(
+            enable_web_search=enable_web_search,
+            extra_tools=extra_tools,
+            web_search_max_uses=web_search_max_uses,
+            request_kwargs=request_kwargs,
+        )
+        if request_tools:
+            request_kwargs["tools"] = request_tools
+        return request_kwargs
+
+    def _consume_stream_round(
+        self,
+        client: Any,
+        request_kwargs: Dict[str, Any],
+        possible_pseudo_tools: set[str],
+    ) -> Generator[str, None, tuple[_StreamRound, str, bool]]:
+        streamed_round = _StreamRound()
+        held_text = ""
+        text_released = False
+        for chunk in client.chat.completions.create(**request_kwargs):
+            streamed_round.last_response = chunk
+            if getattr(chunk, "usage", None) is not None:
+                streamed_round.usage_response = chunk
+            choices = getattr(chunk, "choices", None) or []
+            if not choices:
+                continue
+            choice = choices[0]
+            finish_reason = getattr(choice, "finish_reason", None)
+            if finish_reason is not None:
+                streamed_round.finish_reason = finish_reason
+            delta = getattr(choice, "delta", None)
+            if delta is None:
+                continue
+            self._accumulate_stream_delta(streamed_round, delta)
+            content = str(self._field(delta, "content") or "")
+            if not content:
+                continue
+            if text_released:
+                yield content
+                continue
+            held_text += content
+            if not self._could_be_pseudo_tool_call(
+                held_text,
+                possible_pseudo_tools,
+            ):
+                yield held_text
+                held_text = ""
+                text_released = True
+        return streamed_round, held_text, text_released
+
+    @staticmethod
+    def _field(value: Any, name: str, default: Any = None) -> Any:
+        if isinstance(value, Mapping):
+            return value.get(name, default)
+        return getattr(value, name, default)
+
+    @classmethod
+    def _accumulate_stream_delta(
+        cls,
+        streamed_round: _StreamRound,
+        delta: Any,
+    ) -> None:
+        content = cls._field(delta, "content")
+        if content:
+            streamed_round.text_parts.append(str(content))
+
+        annotations = cls._field(delta, "annotations") or []
+        streamed_round.annotations.extend(annotations)
+
+        for position, fragment in enumerate(cls._field(delta, "tool_calls") or []):
+            try:
+                index = int(cls._field(fragment, "index", position))
+            except TypeError, ValueError:
+                index = position
+            accumulated = streamed_round.tool_calls.setdefault(
+                index,
+                _StreamToolCall(index=index),
+            )
+            call_id = cls._field(fragment, "id")
+            call_type = cls._field(fragment, "type")
+            function = cls._field(fragment, "function")
+            if call_id:
+                accumulated.id += str(call_id)
+            if call_type:
+                accumulated.type = str(call_type)
+            if function is not None:
+                name = cls._field(function, "name")
+                arguments = cls._field(function, "arguments")
+                if name:
+                    accumulated.name += str(name)
+                if arguments:
+                    accumulated.arguments += str(arguments)
+
+    @staticmethod
+    def _extra_tool_names(
+        extra_tools: Optional[List[Dict[str, Any]]],
+    ) -> set[str]:
+        names: set[str] = set()
+        for tool in extra_tools or []:
+            function = tool.get("function")
+            if isinstance(function, Mapping):
+                name = str(function.get("name") or "")
+                if name:
+                    names.add(name)
+        return names
+
+    @staticmethod
+    def _could_be_pseudo_tool_call(text: str, tool_names: set[str]) -> bool:
+        stripped = text.lstrip()
+        if not stripped:
+            return bool(tool_names)
+        return any(
+            name.startswith(stripped) or stripped.startswith(f"{name}(") for name in tool_names
+        )

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -168,15 +168,6 @@ class OpenRouterProvider(StreamingAIProvider):
                     usage_response,
                     message,
                 )
-                if on_usage_result is not None:
-                    on_usage_result(
-                        self._runtime._build_round_result(
-                            usage_response,
-                            message,
-                            round_idx,
-                            metadata=web_metadata,
-                        )
-                    )
                 remaining_web_search_uses = self._runtime._remaining_web_search_uses(
                     remaining_web_search_uses,
                     usage_response,
@@ -190,6 +181,13 @@ class OpenRouterProvider(StreamingAIProvider):
                     round_idx,
                 )
                 if known_calls:
+                    self._report_stream_usage(
+                        on_usage_result,
+                        usage_response,
+                        message,
+                        round_idx,
+                        web_metadata,
+                    )
                     if held_text:
                         yield held_text
                     current_messages = self._tool_runtime.apply_tool_calls(
@@ -206,6 +204,13 @@ class OpenRouterProvider(StreamingAIProvider):
                     extra_tools,
                 )
                 if pseudo_call is not None and not text_released:
+                    self._report_stream_usage(
+                        on_usage_result,
+                        usage_response,
+                        message,
+                        round_idx,
+                        web_metadata,
+                    )
                     current_messages = self._tool_runtime.apply_tool_calls(
                         SimpleNamespace(content=""),
                         [pseudo_call],
@@ -213,6 +218,18 @@ class OpenRouterProvider(StreamingAIProvider):
                         tool_context or {},
                     )
                     continue
+
+                text_override = self._runtime._stream_text_override(web_metadata)
+                if text_override is not None:
+                    web_metadata["stream_text_override"] = text_override
+                self._report_stream_usage(
+                    on_usage_result,
+                    usage_response,
+                    message,
+                    round_idx,
+                    web_metadata,
+                    text_override=text_override,
+                )
 
                 if held_text:
                     yield held_text
@@ -229,6 +246,28 @@ class OpenRouterProvider(StreamingAIProvider):
                 {"model": self._primary_model},
             )
             raise
+
+    def _report_stream_usage(
+        self,
+        callback: Optional[Callable[[AIUsageResult], None]],
+        response: Any,
+        message: Any,
+        round_idx: int,
+        metadata: Dict[str, Any],
+        *,
+        text_override: Optional[str] = None,
+    ) -> None:
+        if callback is None:
+            return
+        callback(
+            self._runtime._build_round_result(
+                response,
+                message,
+                round_idx,
+                metadata=metadata,
+                text_override=text_override,
+            )
+        )
 
     def _build_stream_request(
         self,
@@ -267,6 +306,9 @@ class OpenRouterProvider(StreamingAIProvider):
         held_text = ""
         text_released = False
         for chunk in client.chat.completions.create(**request_kwargs):
+            stream_error = self._field(chunk, "error")
+            if stream_error:
+                raise RuntimeError(f"OpenRouter stream failed: {stream_error}")
             streamed_round.last_response = chunk
             if getattr(chunk, "usage", None) is not None:
                 streamed_round.usage_response = chunk
@@ -275,6 +317,11 @@ class OpenRouterProvider(StreamingAIProvider):
                 continue
             choice = choices[0]
             finish_reason = getattr(choice, "finish_reason", None)
+            if finish_reason == "error":
+                choice_error = self._field(choice, "error")
+                raise RuntimeError(
+                    f"OpenRouter stream failed: {choice_error or 'unknown provider error'}"
+                )
             if finish_reason is not None:
                 streamed_round.finish_reason = finish_reason
             delta = getattr(choice, "delta", None)

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -697,6 +697,12 @@ class ProviderRuntime:
         return metadata
 
     @staticmethod
+    def _stream_text_override(metadata: Mapping[str, Any]) -> Optional[str]:
+        if metadata.get("web_search_grounded") is False:
+            return _UNGROUNDED_SEARCH_MESSAGE
+        return None
+
+    @staticmethod
     def _web_search_max_uses(tool: Mapping[str, Any]) -> int:
         parameters = ensure_mapping(tool.get("parameters")) or {}
         try:

--- a/api/providers/service.py
+++ b/api/providers/service.py
@@ -326,6 +326,9 @@ class ProviderService:
         if response_meta is not None:
 
             def record_usage(result: AIUsageResult) -> None:
+                text_override = result.metadata.pop("stream_text_override", None)
+                if isinstance(text_override, str) and text_override.strip():
+                    response_meta["stream_text_override"] = text_override
                 self.append_billing_segment(response_meta, result)
 
             on_usage_result = record_usage

--- a/api/providers/service.py
+++ b/api/providers/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping
 from contextvars import ContextVar, Token
 from logging import Logger
-from typing import Any
+from typing import Any, Callable
 
 from groq import Groq
 from openai import OpenAI
@@ -320,13 +320,26 @@ class ProviderService:
         enable_web_search: bool = True,
         extra_tools: list[dict[str, Any]] | None = None,
         tool_context: dict[str, Any] | None = None,
+        response_meta: dict[str, Any] | None = None,
     ) -> Iterator[tuple[str, str]]:
+        on_usage_result: Callable[[AIUsageResult], None] | None = None
+        if response_meta is not None:
+
+            def record_usage(result: AIUsageResult) -> None:
+                self.append_billing_segment(response_meta, result)
+
+            on_usage_result = record_usage
+        stream_kwargs: dict[str, Any] = {
+            "enable_web_search": enable_web_search,
+            "extra_tools": extra_tools,
+            "tool_context": tool_context,
+        }
+        if on_usage_result is not None:
+            stream_kwargs["on_usage_result"] = on_usage_result
         return self.get_chain().stream(
             system_message,
             messages,
-            enable_web_search=enable_web_search,
-            extra_tools=extra_tools,
-            tool_context=tool_context,
+            **stream_kwargs,
         )
 
     def is_scope_available(self, scope: str) -> bool:

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -663,27 +663,37 @@ def test_openrouter_stream_uses_tool_runtime_result_without_final_no_tools_call(
     from api.providers.openrouter import OpenRouterProvider
     from api.tools.runtime import ToolRuntime
 
-    pseudo_call_response = _FakeResponse(
-        [
-            _FakeChoice(
-                "stop",
+    def stream_chunk(content, finish_reason=None):
+        return SimpleNamespace(
+            choices=[
                 SimpleNamespace(
-                    content='web_fetch("https://example.com/bts")',
-                    tool_calls=[],
-                    annotations=[],
-                ),
-            )
-        ]
-    )
-    final_response = _FakeResponse(
+                    finish_reason=finish_reason,
+                    delta=SimpleNamespace(
+                        content=content,
+                        tool_calls=[],
+                        annotations=[],
+                    ),
+                )
+            ],
+            usage=None,
+        )
+
+    client = _FakeClient(
         [
-            _FakeChoice(
-                "stop",
-                SimpleNamespace(content="respuesta final", tool_calls=[], annotations=[]),
-            )
+            iter(
+                [
+                    stream_chunk('web_fetch("https://example.com/bts")'),
+                    stream_chunk(None, "stop"),
+                ]
+            ),
+            iter(
+                [
+                    stream_chunk("respuesta "),
+                    stream_chunk("final", "stop"),
+                ]
+            ),
         ]
     )
-    client = _FakeClient([pseudo_call_response, final_response])
     execute_tool_fn = MagicMock(return_value=SimpleNamespace(output="contenido bts"))
     provider = OpenRouterProvider(
         get_client=lambda: client,
@@ -716,7 +726,7 @@ def test_openrouter_stream_uses_tool_runtime_result_without_final_no_tools_call(
         )
     )
 
-    assert chunks == ["respuesta final"]
+    assert chunks == ["respuesta ", "final"]
     assert_no_raw_tool_syntax("".join(chunks))
     execute_tool_fn.assert_called_once_with(
         "web_fetch", {"url": "https://example.com/bts"}, {"chat_id": "123"}

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -287,6 +287,7 @@ def test_openrouter_stream_executes_fragmented_tool_call_and_reports_each_round(
         2,
         1,
     ]
+    assert all("stream_text_override" not in result.metadata for result in usage_results)
 
 
 def test_openrouter_stream_uses_web_search_branch_when_enabled():
@@ -296,12 +297,28 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
     from api.providers.openrouter import OpenRouterProvider
 
     create_calls: list[dict[str, Any]] = []
+    usage_results: list[AIUsageResult] = []
 
     def create(**kwargs):
         create_calls.append(kwargs)
         return iter([
             SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="web"))]),
-            SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=" answer"))]),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        delta=SimpleNamespace(content=" answer"),
+                    )
+                ]
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 2,
+                    "server_tool_use": {"web_search_requests": 1},
+                },
+            ),
         ])
 
     client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
@@ -314,10 +331,10 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             kind=kwargs["kind"],
             text=kwargs["text"],
             model=kwargs["model"],
-            usage={},
+            usage=kwargs["response"].usage,
             metadata=kwargs.get("metadata") or {},
         ),
-        extract_usage_map=lambda r: {},
+        extract_usage_map=lambda response: response.usage,
         primary_model="test-model",
     )
 
@@ -326,12 +343,74 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             {"role": "system", "content": "sys"},
             [{"role": "user", "content": "hola"}],
             enable_web_search=True,
+            on_usage_result=usage_results.append,
         )
     )
 
     assert chunks == ["web", " answer"]
     assert_no_raw_tool_syntax("".join(chunks))
     assert create_calls[0]["tools"] == [{"type": "web_search"}]
+    assert usage_results[0].text.startswith("No pude verificar eso con fuentes")
+    assert usage_results[0].metadata["web_search_grounded"] is False
+    assert usage_results[0].metadata["stream_text_override"] == usage_results[0].text
+
+
+def test_openrouter_stream_raises_on_provider_error_chunk():
+    from types import SimpleNamespace
+
+    from api.providers.openrouter import OpenRouterProvider
+
+    admin_report = MagicMock()
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **_kwargs: iter(
+                    [
+                        SimpleNamespace(
+                            choices=[
+                                SimpleNamespace(
+                                    finish_reason=None,
+                                    delta=SimpleNamespace(content="partial"),
+                                )
+                            ],
+                            error=None,
+                            usage=None,
+                        ),
+                        SimpleNamespace(
+                            choices=[
+                                SimpleNamespace(
+                                    finish_reason="error",
+                                    delta=SimpleNamespace(content=""),
+                                )
+                            ],
+                            error={"code": 502, "message": "provider disconnected"},
+                            usage=None,
+                        ),
+                    ]
+                )
+            )
+        )
+    )
+    provider = OpenRouterProvider(
+        get_client=lambda: client,
+        admin_report=admin_report,
+        increment_request_count=lambda: None,
+        build_web_search_tool=lambda: {},
+        build_usage_result=lambda **kwargs: MagicMock(),
+        extract_usage_map=lambda response: {},
+        primary_model="test-model",
+    )
+
+    with pytest.raises(RuntimeError, match="provider disconnected"):
+        list(
+            provider.stream(
+                {"role": "system", "content": "sys"},
+                [{"role": "user", "content": "hola"}],
+                enable_web_search=False,
+            )
+        )
+
+    admin_report.assert_called_once()
 
 
 def test_stream_to_telegram_sends_first_token_without_placeholder():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -95,10 +95,198 @@ def test_openrouter_stream_uses_streaming_path_when_tools_present():
         )
     )
 
-    assert chunks == ["hola final"]
+    assert chunks == ["hola", " final"]
     assert len(create_calls) == 1
     assert create_calls[0]["tools"]
-    assert "stream" not in create_calls[0]
+    assert create_calls[0]["stream"] is True
+
+
+def test_openrouter_stream_executes_fragmented_tool_call_and_reports_each_round():
+    from types import SimpleNamespace
+
+    from api.ai.pricing import AIUsageResult
+    from api.providers.openrouter import OpenRouterProvider
+    from api.tools.runtime import ToolRuntime
+
+    create_calls: list[dict[str, Any]] = []
+    responses = [
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason=None,
+                        delta=SimpleNamespace(
+                            content=None,
+                            annotations=[{"type": "url_citation"}],
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=0,
+                                    id="call_1",
+                                    type="function",
+                                    function=SimpleNamespace(
+                                        name="calculate",
+                                        arguments='{"expression":"1',
+                                    ),
+                                )
+                            ],
+                        ),
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="tool_calls",
+                        delta=SimpleNamespace(
+                            content=None,
+                            annotations=[],
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=0,
+                                    id=None,
+                                    type=None,
+                                    function=SimpleNamespace(
+                                        name=None,
+                                        arguments='+1"}',
+                                    ),
+                                )
+                            ],
+                        ),
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage={
+                    "prompt_tokens": 10,
+                    "completion_tokens": 2,
+                    "server_tool_use": {"web_search_requests": 2},
+                },
+            ),
+        ],
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason=None,
+                        delta=SimpleNamespace(
+                            content="resultado ",
+                            annotations=[{"type": "url_citation"}],
+                            tool_calls=[],
+                        ),
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        delta=SimpleNamespace(
+                            content="final",
+                            annotations=[],
+                            tool_calls=[],
+                        ),
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage={
+                    "prompt_tokens": 20,
+                    "completion_tokens": 4,
+                    "server_tool_use": {"web_search_requests": 1},
+                },
+            ),
+        ],
+    ]
+
+    def create(**kwargs):
+        create_calls.append(kwargs)
+        return iter(responses.pop(0))
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    execute_tool = MagicMock(return_value=SimpleNamespace(output="2"))
+    usage_results: list[AIUsageResult] = []
+    provider = OpenRouterProvider(
+        get_client=lambda: client,
+        admin_report=lambda *a, **k: None,
+        increment_request_count=lambda: None,
+        build_web_search_tool=lambda: {
+            "type": "openrouter:web_search",
+            "parameters": {
+                "engine": "firecrawl",
+                "max_results": 10,
+                "max_uses": 3,
+                "max_total_results": 30,
+            },
+        },
+        build_usage_result=lambda **kwargs: AIUsageResult(
+            kind=kwargs["kind"],
+            text=kwargs["text"],
+            model=kwargs["model"],
+            usage=kwargs["response"].usage,
+            metadata=kwargs.get("metadata") or {},
+        ),
+        extract_usage_map=lambda response: response.usage,
+        primary_model="test-model",
+        tool_runtime=ToolRuntime(
+            execute_tool_fn=execute_tool,
+            tool_registry={"calculate": object()},
+            print_fn=lambda *_args: None,
+        ),
+    )
+
+    chunks = list(
+        provider.stream(
+            {"role": "system", "content": "sys"},
+            [{"role": "user", "content": "busca y calcula"}],
+            enable_web_search=True,
+            extra_tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "calculate"},
+                }
+            ],
+            tool_context={"chat_id": "123"},
+            on_usage_result=usage_results.append,
+        )
+    )
+
+    assert chunks == ["resultado ", "final"]
+    assert_no_raw_tool_syntax("".join(chunks))
+    execute_tool.assert_called_once_with(
+        "calculate",
+        {"expression": "1+1"},
+        {"chat_id": "123"},
+    )
+    assert create_calls[0]["stream"] is True
+    assert create_calls[1]["stream"] is True
+    assert create_calls[1]["tools"][0]["parameters"]["max_uses"] == 1
+    assert create_calls[1]["messages"][-1] == {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": "2",
+    }
+    assert [result.usage for result in usage_results] == [
+        {
+            "prompt_tokens": 10,
+            "completion_tokens": 2,
+            "server_tool_use": {"web_search_requests": 2},
+        },
+        {
+            "prompt_tokens": 20,
+            "completion_tokens": 4,
+            "server_tool_use": {"web_search_requests": 1},
+        },
+    ]
+    assert [result.metadata["web_search_requests"] for result in usage_results] == [
+        2,
+        1,
+    ]
 
 
 def test_openrouter_stream_uses_web_search_branch_when_enabled():

--- a/tests/test_streaming_wiring.py
+++ b/tests/test_streaming_wiring.py
@@ -25,13 +25,15 @@ def test_handle_ai_stream_response_returns_final_text_and_stores_stream_metadata
 
     assert result == "hola"
     assert_no_raw_tool_syntax(result)
-    ask_stream.assert_called_once_with(
-        [{"role": "user", "content": "hola"}],
-        chat_id="123",
-        user_name="@ana",
-        user_id=55,
-        timezone_offset=-3,
-    )
+    ask_stream.assert_called_once()
+    assert ask_stream.call_args.args == ([{"role": "user", "content": "hola"}],)
+    assert ask_stream.call_args.kwargs == {
+        "chat_id": "123",
+        "user_name": "@ana",
+        "user_id": 55,
+        "timezone_offset": -3,
+        "response_meta": response_meta,
+    }
     consume_stream_to_telegram.assert_called_once()
     assert response_meta["streamed_text"] == "hola"
     assert response_meta["streamed_message_id"] == "777"
@@ -224,6 +226,7 @@ def test_ask_ai_stream_forwards_extra_tools_and_tool_context():
 
 def test_ask_ai_stream_end_to_end_with_internal_tool():
     from api.ai.pricing import AIUsageResult
+
     ask_ai_stream = index.app_runtime.ai.stream
     from api.providers.base import ProviderChain
 
@@ -288,6 +291,7 @@ def test_ask_ai_stream_end_to_end_with_internal_tool():
 
 def test_ask_ai_stream_end_to_end_with_web_search():
     from api.ai.pricing import AIUsageResult
+
     ask_ai_stream = index.app_runtime.ai.stream
     from api.providers.base import ProviderChain
 
@@ -372,10 +376,25 @@ def test_handle_ai_stream_response_end_to_end_no_tool_leak():
 
 
 def test_stream_with_providers_forwards_extra_tools_and_tool_context():
+    from api.ai.pricing import AIUsageResult
+
     chain = MagicMock()
-    chain.stream.return_value = iter([("openrouter", "ok")])
+
+    def stream(*_args, **kwargs):
+        kwargs["on_usage_result"](
+            AIUsageResult(
+                kind="chat",
+                text="ok",
+                model="test-model",
+                usage={"prompt_tokens": 7, "completion_tokens": 2},
+            )
+        )
+        return iter([("openrouter", "ok")])
+
+    chain.stream.side_effect = stream
     extra_tools = [{"type": "function", "function": {"name": "echo"}}]
     tool_context = {"chat_id": "123"}
+    response_meta: dict[str, Any] = {}
 
     with patch("api.index.app_runtime.providers.get_chain", return_value=chain):
         result = index.app_runtime.providers.stream(
@@ -384,17 +403,32 @@ def test_stream_with_providers_forwards_extra_tools_and_tool_context():
             enable_web_search=False,
             extra_tools=extra_tools,
             tool_context=tool_context,
+            response_meta=response_meta,
         )
         tokens = list(result)
 
     assert tokens == [("openrouter", "ok")]
-    chain.stream.assert_called_once_with(
+    chain.stream.assert_called_once()
+    assert chain.stream.call_args.args == (
         {"role": "system", "content": "sys"},
         [{"role": "user", "content": "hola"}],
-        enable_web_search=False,
-        extra_tools=extra_tools,
-        tool_context=tool_context,
     )
+    assert chain.stream.call_args.kwargs["enable_web_search"] is False
+    assert chain.stream.call_args.kwargs["extra_tools"] == extra_tools
+    assert chain.stream.call_args.kwargs["tool_context"] == tool_context
+    assert callable(chain.stream.call_args.kwargs["on_usage_result"])
+    assert response_meta["billing_segments"] == [
+        {
+            "kind": "chat",
+            "text": "ok",
+            "model": "test-model",
+            "usage": {"prompt_tokens": 7, "completion_tokens": 2},
+            "audio_seconds": None,
+            "cached": False,
+            "source": "groq",
+            "metadata": {},
+        }
+    ]
 
 
 def test_provider_chain_stream_uses_complete_fallback_for_tool_requests():

--- a/tests/test_streaming_wiring.py
+++ b/tests/test_streaming_wiring.py
@@ -39,6 +39,36 @@ def test_handle_ai_stream_response_returns_final_text_and_stores_stream_metadata
     assert response_meta["streamed_message_id"] == "777"
 
 
+def test_handle_ai_stream_response_applies_grounding_override():
+    handle_ai_stream_response = index.app_runtime.responses.stream_handler
+    response_meta: dict[str, Any] = {"stream_text_override": "grounding warning"}
+
+    with patch(
+        "api.index.app_runtime.ai.stream",
+        return_value=iter([("openrouter", "unsupported claim")]),
+    ):
+        with patch(
+            "api.index.app_runtime.responses._deps.consume_stream",
+            return_value=("unsupported claim", "777"),
+        ):
+            with patch(
+                "api.index.app_runtime.responses._deps.edit_message"
+            ) as edit_stream_message:
+                result = handle_ai_stream_response(
+                    [{"role": "user", "content": "search"}],
+                    response_meta=response_meta,
+                    chat_id="123",
+                    user_id=55,
+                    user_name="@ana",
+                    timezone_offset=-3,
+                )
+
+    assert result == "grounding warning"
+    edit_stream_message.assert_called_once_with("123", 777, "grounding warning")
+    assert response_meta["streamed_text"] == "grounding warning"
+    assert "stream_text_override" not in response_meta
+
+
 def test_finalize_message_response_saves_streamed_text_to_redis():
     from api.bot.message_handler import (
         MessageContext,
@@ -387,6 +417,7 @@ def test_stream_with_providers_forwards_extra_tools_and_tool_context():
                 text="ok",
                 model="test-model",
                 usage={"prompt_tokens": 7, "completion_tokens": 2},
+                metadata={"stream_text_override": "grounding warning"},
             )
         )
         return iter([("openrouter", "ok")])
@@ -417,6 +448,7 @@ def test_stream_with_providers_forwards_extra_tools_and_tool_context():
     assert chain.stream.call_args.kwargs["extra_tools"] == extra_tools
     assert chain.stream.call_args.kwargs["tool_context"] == tool_context
     assert callable(chain.stream.call_args.kwargs["on_usage_result"])
+    assert response_meta["stream_text_override"] == "grounding warning"
     assert response_meta["billing_segments"] == [
         {
             "kind": "chat",


### PR DESCRIPTION
## Summary

- stream OpenRouter responses when local tools and Firecrawl are available
- accumulate fragmented tool calls, execute them, and stream the following model round
- collect usage from every streamed round and pass it to the existing billing settlement path
- preserve Firecrawl limits, citation metadata, and pseudo-tool syntax suppression across rounds

## Why

Requests with local tools previously fell back to a blocking completion. This delayed the first visible answer and prevented the streaming path from recording provider usage for billing. Streamed tool-call arguments can also arrive in fragments, so they must be assembled before tool execution.

## Impact

Tool-enabled answers now start streaming without removing tool access. Billing receives the token and Firecrawl usage from each OpenRouter round. Existing non-streaming behavior and provider fallback remain available.

## Validation

- `python -m pytest -q` — 886 passed
- `ruff check api/ tests/`
- `mypy api/providers/base.py api/providers/service.py api/providers/openrouter.py api/ai/request_runtime.py api/bot/responses.py`

Repository-wide mypy still reports two pre-existing errors in `api/services/maintenance.py`; this PR does not modify that file.
