### PR TITLE
Use direct Firecrawl web search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,8 @@ GROQ_FREE_API_KEY=your_free_groq_api_key
 GROQ_API_KEY=your_paid_groq_api_key
 # OpenRouter key for chat and vision
 OPENROUTER_API_KEY=your_openrouter_api_key
-# Cloudflare AI Gateway
-CF_AIG_BASE_URL=https://gateway.ai.cloudflare.com/v1/YOUR_ACCOUNT_ID/YOUR_GATEWAY_NAME/compat
-CF_AIG_TOKEN=your_cloudflare_ai_gateway_token
+# Firecrawl key for direct web search
+FIRECRAWL_API_KEY=your_firecrawl_api_key
 
 # Monitoring
 ADMIN_CHAT_ID=your_telegram_chat_id_for_admin_reports

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ uv run --locked python run_polling.py
 | `GROQ_API_KEY` | Paid Groq API key for transcription |
 | `GROQ_FREE_API_KEY` | Optional free-tier Groq key for transcription |
 | `OPENROUTER_API_KEY` | OpenRouter API key for chat/vision |
-| `CF_AIG_TOKEN` | Cloudflare AI Gateway token forwarded to OpenRouter requests |
+| `FIRECRAWL_API_KEY` | Firecrawl API key for direct web search |
 | `GIPHY_API_KEY` | Giphy API key for `/gm` and `/gn` |
 | `ADMIN_CHAT_ID` | Telegram chat ID for error reports |
 | `FRIENDLY_INSTANCE_NAME` | Instance name for admin reports |

--- a/api/ai/request_runtime.py
+++ b/api/ai/request_runtime.py
@@ -104,6 +104,8 @@ def build_ai_request(
         "config_redis": config_redis,
         "timezone_offset": timezone_offset,
     }
+    if enable_web_search:
+        tool_context["web_search_enabled"] = True
     if chat_id:
         tool_context["chat_id"] = chat_id
     if user_name:

--- a/api/index.py
+++ b/api/index.py
@@ -146,6 +146,7 @@ from api.providers import OpenRouterProvider, ProviderChain
 import api.tools.crypto_prices
 import api.tools.calculate
 import api.tools.web_fetch
+import api.tools.web_search
 import api.tools.task_set
 import api.tools.get_chat_members
 from api.tools import get_all_tool_schemas
@@ -339,7 +340,7 @@ VISION_MODEL = "google/gemini-3.1-flash-lite-preview"
 GROQ_TRANSCRIBE_MODEL = "groq/whisper-large-v3"
 OPENROUTER_TRANSCRIBE_MODEL = "google/gemini-3.1-flash-lite-preview"
 
-OPENROUTER_WEB_SEARCH_MAX_RESULTS = 10
+OPENROUTER_WEB_SEARCH_MAX_RESULTS = 5
 OPENROUTER_WEB_SEARCH_MAX_QUERIES = 3
 _MAX_TOOL_ROUNDS = 5
 _TOOL_RUNTIME = ToolRuntime()

--- a/api/providers/config.py
+++ b/api/providers/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
 DEFAULT_OPENROUTER_URL = "https://openrouter.ai/api/v1"
 
@@ -26,24 +25,14 @@ def get_openrouter_api_key(*, environment: Mapping[str, str]) -> str | None:
     return _clean_value(environment.get("OPENROUTER_API_KEY"))
 
 
-def get_openrouter_base_url(*, environment: Mapping[str, str]) -> str:
-    value = _clean_value(environment.get("CF_AIG_BASE_URL"))
-    if not value or "gateway.ai.cloudflare.com" not in value:
-        return DEFAULT_OPENROUTER_URL
-    parsed = urlparse(value)
-    path = parsed.path.rstrip("/")
-    if not path:
-        return DEFAULT_OPENROUTER_URL
-    base_path = path.rsplit("/", 1)[0]
-    openrouter_path = f"{base_path}/openrouter" if base_path else "/openrouter"
-    return urlunparse(parsed._replace(path=openrouter_path))
+def get_openrouter_base_url() -> str:
+    return DEFAULT_OPENROUTER_URL
 
 
 def build_openrouter_client(
     *,
     get_api_key: Callable[[], str | None],
     get_base_url: Callable[[], str | None],
-    environment: Mapping[str, str],
     client_factory: Callable[..., Any],
     default_headers: Mapping[str, str] | None = None,
     timeout: float = 60.0,
@@ -52,10 +41,6 @@ def build_openrouter_client(
     base_url = get_base_url()
     if not api_key or not base_url:
         return None
-    headers = dict(default_headers or {})
-    gateway_token = environment.get("CF_AIG_TOKEN")
-    if gateway_token:
-        headers["cf-aig-authorization"] = f"Bearer {gateway_token}"
     kwargs: dict[str, Any] = {
         "api_key": api_key,
         "base_url": base_url,
@@ -64,8 +49,8 @@ def build_openrouter_client(
         # SDK and the application from multiplying slow server-tool attempts.
         "max_retries": 0,
     }
-    if headers:
-        kwargs["default_headers"] = headers
+    if default_headers:
+        kwargs["default_headers"] = dict(default_headers)
     return client_factory(**kwargs)
 
 
@@ -73,7 +58,6 @@ def build_groq_openai_client(
     account: str,
     *,
     get_api_key: Callable[[str], str | None],
-    environment: Mapping[str, str],
     client_factory: Callable[..., Any],
     default_headers: Mapping[str, str] | None = None,
 ) -> Any | None:
@@ -81,18 +65,12 @@ def build_groq_openai_client(
     if not api_key:
         print(f"Groq API key not configured for account={account}")
         return None
-    headers = dict(default_headers or {})
-    gateway_token = environment.get("CF_AIG_TOKEN")
-    if gateway_token:
-        headers["cf-aig-authorization"] = f"Bearer {gateway_token}"
     kwargs: dict[str, Any] = {
         "api_key": api_key,
-        "base_url": environment.get(
-            "CF_AIG_BASE_URL", "https://api.groq.com/openai/v1"
-        ),
+        "base_url": "https://api.groq.com/openai/v1",
     }
-    if headers:
-        kwargs["default_headers"] = headers
+    if default_headers:
+        kwargs["default_headers"] = dict(default_headers)
     return client_factory(**kwargs)
 
 

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -136,6 +136,7 @@ class OpenRouterProvider(StreamingAIProvider):
         output_token_limit = chat_output_token_limit(self._primary_model)
         current_messages = list(messages)
         remaining_web_search_uses = self._runtime._configured_web_search_max_uses(enable_web_search)
+        total_web_search_requests = 0
         possible_pseudo_tools = self._extra_tool_names(extra_tools)
 
         try:
@@ -155,6 +156,7 @@ class OpenRouterProvider(StreamingAIProvider):
                         client,
                         request_kwargs,
                         possible_pseudo_tools,
+                        hold_all_text=total_web_search_requests > 0,
                     )
                 )
 
@@ -168,6 +170,11 @@ class OpenRouterProvider(StreamingAIProvider):
                     usage_response,
                     message,
                 )
+                round_web_search_requests = self._runtime._web_search_request_count(
+                    usage_response,
+                    message,
+                )
+                total_web_search_requests += round_web_search_requests
                 remaining_web_search_uses = self._runtime._remaining_web_search_uses(
                     remaining_web_search_uses,
                     usage_response,
@@ -188,8 +195,6 @@ class OpenRouterProvider(StreamingAIProvider):
                         round_idx,
                         web_metadata,
                     )
-                    if held_text:
-                        yield held_text
                     current_messages = self._tool_runtime.apply_tool_calls(
                         message,
                         known_calls,
@@ -219,6 +224,14 @@ class OpenRouterProvider(StreamingAIProvider):
                     )
                     continue
 
+                if total_web_search_requests > 0:
+                    web_metadata["web_search_grounded"] = (
+                        bool(web_metadata.get("web_search_citation_count"))
+                        or self._runtime._answer_cites_tool_source(
+                            streamed_round.text,
+                            current_messages,
+                        )
+                    )
                 text_override = self._runtime._stream_text_override(web_metadata)
                 if text_override is not None:
                     web_metadata["stream_text_override"] = text_override
@@ -231,7 +244,9 @@ class OpenRouterProvider(StreamingAIProvider):
                     text_override=text_override,
                 )
 
-                if held_text:
+                if text_override is not None and not text_released:
+                    yield text_override
+                elif held_text:
                     yield held_text
 
                 if streamed_round.finish_reason in {"stop", "length", None}:
@@ -301,6 +316,8 @@ class OpenRouterProvider(StreamingAIProvider):
         client: Any,
         request_kwargs: Dict[str, Any],
         possible_pseudo_tools: set[str],
+        *,
+        hold_all_text: bool = False,
     ) -> Generator[str, None, tuple[_StreamRound, str, bool]]:
         streamed_round = _StreamRound()
         held_text = ""
@@ -330,6 +347,9 @@ class OpenRouterProvider(StreamingAIProvider):
             self._accumulate_stream_delta(streamed_round, delta)
             content = str(self._field(delta, "content") or "")
             if not content:
+                continue
+            if hold_all_text:
+                held_text += content
                 continue
             if text_released:
                 yield content

--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -227,7 +227,7 @@ class OpenRouterProvider(StreamingAIProvider):
                 if total_web_search_requests > 0:
                     web_metadata["web_search_grounded"] = (
                         bool(web_metadata.get("web_search_citation_count"))
-                        or self._runtime._answer_cites_tool_source(
+                        or self._runtime._answer_cites_web_search_source(
                             streamed_round.text,
                             current_messages,
                         )

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -793,19 +793,61 @@ class ProviderRuntime:
         return count
 
     @staticmethod
-    def _answer_cites_tool_source(
+    def _web_search_call_ids(
+        current_messages: List[Dict[str, Any]],
+    ) -> set[str]:
+        web_search_call_ids: set[str] = set()
+        for item in current_messages:
+            if str(item.get("role") or "") != "assistant":
+                continue
+            for tool_call in item.get("tool_calls") or []:
+                call = ensure_mapping(tool_call) or {}
+                function = ensure_mapping(call.get("function")) or {}
+                if str(function.get("name") or "") != "web_search":
+                    continue
+                call_id = str(call.get("id") or "")
+                if call_id:
+                    web_search_call_ids.add(call_id)
+        return web_search_call_ids
+
+    @classmethod
+    def _web_search_source_urls(
+        cls,
+        current_messages: List[Dict[str, Any]],
+    ) -> set[str]:
+        web_search_call_ids = cls._web_search_call_ids(current_messages)
+        source_urls: set[str] = set()
+        for item in current_messages:
+            if (
+                str(item.get("role") or "") != "tool"
+                or str(item.get("tool_call_id") or "") not in web_search_call_ids
+            ):
+                continue
+            try:
+                payload = json.loads(str(item.get("content") or ""))
+            except (json.JSONDecodeError, TypeError):
+                continue
+            result_items = (ensure_mapping(payload) or {}).get("results")
+            if not isinstance(result_items, list):
+                continue
+            for result_item in result_items:
+                result = ensure_mapping(result_item) or {}
+                source_url = str(result.get("url") or "").rstrip(".,);]")
+                if source_url:
+                    source_urls.add(source_url)
+        return source_urls
+
+    @classmethod
+    def _answer_cites_web_search_source(
+        cls,
         text: str,
         current_messages: List[Dict[str, Any]],
     ) -> bool:
-        if not text:
-            return False
-        for item in current_messages:
-            if str(item.get("role") or "") != "tool":
-                continue
-            for url in re.findall(r"https?://[^\s\"<>]+", str(item.get("content") or "")):
-                if url.rstrip(".,);]") in text:
-                    return True
-        return False
+        cited_urls = {
+            url.rstrip(".,);]")
+            for url in re.findall(r"https?://[^\s\"<>]+", text)
+        }
+        return bool(cited_urls & cls._web_search_source_urls(current_messages))
 
     def _remaining_web_search_uses(
         self,
@@ -863,7 +905,7 @@ class ProviderRuntime:
             web_metadata["web_search_requests"] = total_web_search_requests
             web_metadata["web_search_grounded"] = (
                 bool(web_metadata.get("web_search_citation_count"))
-                or self._answer_cites_tool_source(
+                or self._answer_cites_web_search_source(
                     str(getattr(message, "content", "") or ""),
                     current_messages,
                 )

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ast
-import copy
 import json
 import re
 import time
@@ -677,6 +676,9 @@ class ProviderRuntime:
                 metadata["web_search_requests"] = int(web_search_requests)
             except (TypeError, ValueError):
                 pass
+        direct_search_requests = self._direct_web_search_request_count(message)
+        if direct_search_requests:
+            metadata["web_search_requests"] = direct_search_requests
         annotations = getattr(message, "annotations", None) or []
         citation_count = sum(
             1
@@ -724,14 +726,17 @@ class ProviderRuntime:
         web_search_max_uses: Optional[int],
         request_kwargs: Dict[str, Any],
     ) -> List[Dict[str, Any]]:
+        # Web search is an application-managed Firecrawl function in
+        # extra_tools. Do not add OpenRouter's opaque server-managed tool.
         tools = list(extra_tools or [])
-        if not enable_web_search or web_search_max_uses == 0:
+        if enable_web_search and web_search_max_uses != 0:
             return tools
-        web_search_tool = copy.deepcopy(self._deps.build_web_search_tool())
-        if web_search_max_uses is not None:
-            self._limit_web_search_tool(web_search_tool, web_search_max_uses)
-        self._apply_web_search_limits(request_kwargs, web_search_tool)
-        return [web_search_tool, *tools]
+        return [
+            tool
+            for tool in tools
+            if str((ensure_mapping(tool.get("function")) or {}).get("name") or "")
+            != "web_search"
+        ]
 
     @staticmethod
     def _limit_web_search_tool(tool: Dict[str, Any], remaining: int) -> None:
@@ -763,6 +768,9 @@ class ProviderRuntime:
             request_count = 0
         if request_count:
             return request_count
+        direct_search_requests = self._direct_web_search_request_count(message)
+        if direct_search_requests:
+            return direct_search_requests
         annotations = getattr(message, "annotations", None) or []
         if any(
             getattr(annotation, "type", None) == "url_citation"
@@ -774,6 +782,30 @@ class ProviderRuntime:
         ):
             return 1
         return 0
+
+    @staticmethod
+    def _direct_web_search_request_count(message: Any) -> int:
+        count = 0
+        for tool_call in getattr(message, "tool_calls", None) or []:
+            function = getattr(tool_call, "function", None)
+            if str(getattr(function, "name", "") or "") == "web_search":
+                count += 1
+        return count
+
+    @staticmethod
+    def _answer_cites_tool_source(
+        text: str,
+        current_messages: List[Dict[str, Any]],
+    ) -> bool:
+        if not text:
+            return False
+        for item in current_messages:
+            if str(item.get("role") or "") != "tool":
+                continue
+            for url in re.findall(r"https?://[^\s\"<>]+", str(item.get("content") or "")):
+                if url.rstrip(".,);]") in text:
+                    return True
+        return False
 
     def _remaining_web_search_uses(
         self,
@@ -829,8 +861,12 @@ class ProviderRuntime:
         web_metadata = self._web_search_metadata(response, message)
         if total_web_search_requests > 0:
             web_metadata["web_search_requests"] = total_web_search_requests
-            web_metadata["web_search_grounded"] = bool(
-                web_metadata.get("web_search_citation_count")
+            web_metadata["web_search_grounded"] = (
+                bool(web_metadata.get("web_search_citation_count"))
+                or self._answer_cites_tool_source(
+                    str(getattr(message, "content", "") or ""),
+                    current_messages,
+                )
             )
         text_override = None
         if web_metadata.get("web_search_grounded") is False:

--- a/api/providers/service.py
+++ b/api/providers/service.py
@@ -113,7 +113,7 @@ class ProviderService:
         return provider_config.get_openrouter_api_key(environment=self.environment)
 
     def get_openrouter_base_url(self) -> str | None:
-        return provider_config.get_openrouter_base_url(environment=self.environment)
+        return provider_config.get_openrouter_base_url()
 
     def get_openrouter_client(
         self,
@@ -124,7 +124,6 @@ class ProviderService:
         return provider_config.build_openrouter_client(
             get_api_key=self.get_openrouter_api_key,
             get_base_url=self.get_openrouter_base_url,
-            environment=self.environment,
             client_factory=self.openai_client_factory,
             default_headers=default_headers,
             timeout=timeout,
@@ -139,7 +138,6 @@ class ProviderService:
         return provider_config.build_groq_openai_client(
             account,
             get_api_key=self.get_groq_api_key,
-            environment=self.environment,
             client_factory=self.openai_client_factory,
             default_headers=default_headers,
         )

--- a/api/tools/web_search.py
+++ b/api/tools/web_search.py
@@ -1,0 +1,207 @@
+"""Search the public web through Firecrawl."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Dict, Mapping
+
+import requests
+
+from api.core.logging import get_logger
+from api.tools.registry import ToolResult, register_tool
+
+
+logger = get_logger(__name__)
+
+_SEARCH_URL = "https://api.firecrawl.dev/v2/search"
+_MAX_RESULTS = 5
+_MAX_ATTEMPTS = 3
+_API_TIMEOUT_MS = 60_000
+_REQUEST_TIMEOUT_SECONDS = (10.0, 75.0)
+_MAX_DESCRIPTION_CHARS = 1_200
+
+
+def _clean_text(value: Any, *, max_chars: int) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= max_chars:
+        return text
+    return f"{text[: max_chars - 1].rstrip()}…"
+
+
+def _response_error(response: requests.Response) -> str:
+    try:
+        payload = response.json()
+    except ValueError:
+        return _clean_text(response.text, max_chars=500) or "respuesta sin detalles"
+    if isinstance(payload, Mapping):
+        return _clean_text(
+            payload.get("error") or payload.get("message") or payload,
+            max_chars=500,
+        )
+    return _clean_text(payload, max_chars=500)
+
+
+def _search_request(query: str, api_key: str) -> requests.Response:
+    payload = {
+        "query": query,
+        "limit": _MAX_RESULTS,
+        "sources": ["web"],
+        "timeout": _API_TIMEOUT_MS,
+        "ignoreInvalidURLs": True,
+    }
+    last_response: requests.Response | None = None
+    started = time.monotonic()
+
+    for attempt in range(_MAX_ATTEMPTS):
+        try:
+            response = requests.post(
+                _SEARCH_URL,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=_REQUEST_TIMEOUT_SECONDS,
+            )
+        except (requests.ConnectionError, requests.Timeout):
+            if attempt == _MAX_ATTEMPTS - 1:
+                raise
+            time.sleep(2**attempt)
+            continue
+
+        last_response = response
+        if response.status_code not in {408, 409, 429} and response.status_code < 500:
+            break
+        if attempt == _MAX_ATTEMPTS - 1:
+            break
+        time.sleep(2**attempt)
+
+    if last_response is None:
+        raise RuntimeError("Firecrawl no devolvió una respuesta")
+
+    logger.info(
+        "web_search: firecrawl query=%r status=%d duration_ms=%d",
+        query,
+        last_response.status_code,
+        round((time.monotonic() - started) * 1000),
+    )
+    return last_response
+
+
+def _extract_results(payload: Mapping[str, Any]) -> list[dict[str, str]]:
+    raw_data = payload.get("data")
+    if isinstance(raw_data, Mapping):
+        raw_results = raw_data.get("web")
+    else:
+        raw_results = raw_data
+    if not isinstance(raw_results, list):
+        return []
+
+    results: list[dict[str, str]] = []
+    for raw_result in raw_results[:_MAX_RESULTS]:
+        if not isinstance(raw_result, Mapping):
+            continue
+        url = _clean_text(raw_result.get("url"), max_chars=2_000)
+        if not url:
+            continue
+        results.append(
+            {
+                "title": _clean_text(raw_result.get("title"), max_chars=300),
+                "url": url,
+                "description": _clean_text(
+                    raw_result.get("description"),
+                    max_chars=_MAX_DESCRIPTION_CHARS,
+                ),
+            }
+        )
+    return results
+
+
+def _parse_search_response(response: requests.Response, query: str) -> ToolResult:
+    if not response.ok:
+        return ToolResult(
+            output=(
+                f"Error de búsqueda: Firecrawl respondió HTTP {response.status_code}: "
+                f"{_response_error(response)}"
+            ),
+            metadata={"status_code": response.status_code},
+        )
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return ToolResult(output="Error de búsqueda: Firecrawl devolvió JSON inválido.")
+    if not isinstance(payload, Mapping) or payload.get("success") is not True:
+        return ToolResult(output=f"Error de búsqueda: {_response_error(response)}")
+
+    results = _extract_results(payload)
+    logger.info(
+        "web_search: firecrawl query=%r results=%d credits=%s request_id=%s",
+        query,
+        len(results),
+        payload.get("creditsUsed"),
+        payload.get("id"),
+    )
+    return ToolResult(
+        output=json.dumps(
+            {
+                "query": query,
+                "results": results,
+                "instruction": "Usá estas fuentes para responder y citá sus URLs.",
+            },
+            ensure_ascii=False,
+        ),
+        metadata={
+            "query": query,
+            "result_count": len(results),
+            "credits_used": payload.get("creditsUsed"),
+            "request_id": payload.get("id"),
+        },
+    )
+
+
+def _execute_web_search(
+    params: Dict[str, Any],
+    context: Dict[str, Any],
+) -> ToolResult:
+    query = _clean_text(params.get("query"), max_chars=500)
+    if not query:
+        return ToolResult(output="Error de búsqueda: falta la consulta.")
+
+    api_key = str(os.environ.get("FIRECRAWL_API_KEY") or "").strip()
+    if not api_key:
+        return ToolResult(output="Error de búsqueda: Firecrawl no está configurado.")
+
+    try:
+        response = _search_request(query, api_key)
+    except requests.Timeout:
+        return ToolResult(output="Error de búsqueda: Firecrawl agotó el tiempo de espera.")
+    except requests.ConnectionError:
+        return ToolResult(output="Error de búsqueda: no se pudo conectar con Firecrawl.")
+    return _parse_search_response(response, query)
+
+
+register_tool(
+    name="web_search",
+    description=(
+        "Search the public web with Firecrawl. Use it for current facts or when the user "
+        "asks you to search. The result contains source URLs that you must cite."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "A concise web search query",
+                "maxLength": 500,
+            },
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+    executor=_execute_web_search,
+    requires_env=["FIRECRAWL_API_KEY"],
+    requires_context=["web_search_enabled"],
+)

--- a/api/tools/web_search.py
+++ b/api/tools/web_search.py
@@ -49,7 +49,6 @@ def _search_request(query: str, api_key: str) -> requests.Response:
         "limit": _MAX_RESULTS,
         "sources": ["web"],
         "timeout": _API_TIMEOUT_MS,
-        "ignoreInvalidURLs": True,
     }
     last_response: requests.Response | None = None
     started = time.monotonic()

--- a/tests/test_ai_requests.py
+++ b/tests/test_ai_requests.py
@@ -602,9 +602,6 @@ def test_complete_with_providers_records_openrouter_billing_on_success(monkeypat
     response_meta = {}
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter_key")
-    monkeypatch.setenv(
-        "CF_AIG_BASE_URL", "https://gateway.ai.cloudflare.com/v1/acct/gw/groq"
-    )
 
     openrouter_result = AIUsageResult(
         kind="chat",
@@ -645,9 +642,6 @@ def test_describe_image_result_returns_none_when_provider_raises(
     monkeypatch,
 ):
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter_key")
-    monkeypatch.setenv(
-        "CF_AIG_BASE_URL", "https://gateway.ai.cloudflare.com/v1/acct/gw/openrouter"
-    )
 
     failing_client = MagicMock()
     failing_client.chat.completions.create.side_effect = Exception("boom")
@@ -665,9 +659,6 @@ def test_describe_image_result_skips_provider_when_image_is_invalid(
     monkeypatch,
 ):
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter_key")
-    monkeypatch.setenv(
-        "CF_AIG_BASE_URL", "https://gateway.ai.cloudflare.com/v1/acct/gw/openrouter"
-    )
 
     client = MagicMock()
 

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -16,7 +16,6 @@ def test_openrouter_client_uses_explicit_timeout(monkeypatch):
 
     monkeypatch.setattr(index.app_runtime.providers, "openai_client_factory", FakeOpenAI)
     monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
-    monkeypatch.delenv("CF_AIG_BASE_URL", raising=False)
 
     client = index.app_runtime.providers.get_openrouter_client()
 
@@ -97,10 +96,6 @@ def test_get_groq_accounts_for_scope_returns_all_configured_accounts(monkeypatch
 
 def test_openrouter_config_helpers(monkeypatch):
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter_key")
-    monkeypatch.setenv(
-        "CF_AIG_BASE_URL", "https://gateway.ai.cloudflare.com/v1/acct/gw/groq"
-    )
-    monkeypatch.setenv("CF_AIG_TOKEN", "cf-token")
 
     with patch("api.index.app_runtime.providers.openai_client_factory") as mock_openai:
         client = index.app_runtime.providers.get_openrouter_client(
@@ -108,20 +103,11 @@ def test_openrouter_config_helpers(monkeypatch):
         )
 
     assert index.app_runtime.providers.get_openrouter_api_key() == "openrouter_key"
-    assert (
-        index.app_runtime.providers.get_openrouter_base_url()
-        == "https://gateway.ai.cloudflare.com/v1/acct/gw/openrouter"
-    )
+    assert index.app_runtime.providers.get_openrouter_base_url() == "https://openrouter.ai/api/v1"
     assert client is mock_openai.return_value
     assert mock_openai.call_args.kwargs["api_key"] == "openrouter_key"
-    assert (
-        mock_openai.call_args.kwargs["base_url"]
-        == "https://gateway.ai.cloudflare.com/v1/acct/gw/openrouter"
-    )
-    assert (
-        mock_openai.call_args.kwargs["default_headers"]["cf-aig-authorization"]
-        == "Bearer cf-token"
-    )
+    assert mock_openai.call_args.kwargs["base_url"] == "https://openrouter.ai/api/v1"
+    assert mock_openai.call_args.kwargs["default_headers"] == {"x-test": "1"}
 
 
 def test_api_index_does_not_expose_unused_agent_limits():
@@ -150,31 +136,24 @@ def test_provider_runtime_enables_firecrawl_web_search():
     client = MagicMock()
     client.chat.completions.create.return_value = response
     runtime = _build_provider_runtime(client=client)
+    search_tool = {
+        "type": "function",
+        "function": {"name": "web_search", "parameters": {"type": "object"}},
+    }
 
     result = runtime.complete(
         {"role": "system", "content": "sys"},
         [{"role": "user", "content": "btc news"}],
         enable_web_search=True,
+        extra_tools=[search_tool],
     )
 
     assert result is not None
     assert result.text == "respuesta con busqueda"
     assert result.metadata["provider"] == "openrouter"
     assert result.metadata["web_search_requests"] == 1
-    assert client.chat.completions.create.call_args.kwargs["tools"] == [
-        {
-            "type": "openrouter:web_search",
-            "parameters": {
-                "engine": "firecrawl",
-                "max_results": 10,
-                "max_uses": 3,
-                "max_total_results": 30,
-            },
-        }
-    ]
-    assert client.chat.completions.create.call_args.kwargs["extra_body"] == {
-        "max_tool_calls": 3
-    }
+    assert client.chat.completions.create.call_args.kwargs["tools"] == [search_tool]
+    assert "extra_body" not in client.chat.completions.create.call_args.kwargs
 
 
 def test_provider_runtime_ignores_invalid_web_search_requests():
@@ -278,7 +257,7 @@ def test_provider_runtime_detects_pydantic_annotation():
     assert result.metadata["web_search_requests"] == 1
 
 
-def test_provider_runtime_sets_explicit_web_search_limits():
+def test_provider_runtime_does_not_add_openrouter_native_web_search():
     response = _build_chat_response(
         text="respuesta con busqueda",
         annotations=[
@@ -299,23 +278,11 @@ def test_provider_runtime_sets_explicit_web_search_limits():
         enable_web_search=True,
     )
 
-    assert client.chat.completions.create.call_args.kwargs["tools"] == [
-        {
-            "type": "openrouter:web_search",
-            "parameters": {
-                "engine": "firecrawl",
-                "max_results": 10,
-                "max_uses": 3,
-                "max_total_results": 30,
-            },
-        }
-    ]
-    assert client.chat.completions.create.call_args.kwargs["extra_body"] == {
-        "max_tool_calls": 3
-    }
+    assert "tools" not in client.chat.completions.create.call_args.kwargs
+    assert "extra_body" not in client.chat.completions.create.call_args.kwargs
 
 
-def test_provider_runtime_includes_web_search_by_default():
+def test_provider_runtime_requires_application_web_search_tool():
     response = _build_chat_response(
         text="respuesta normal",
         usage={"prompt_tokens": 10, "completion_tokens": 5},
@@ -330,7 +297,7 @@ def test_provider_runtime_includes_web_search_by_default():
     )
 
     assert result is not None
-    assert "tools" in client.chat.completions.create.call_args.kwargs
+    assert "tools" not in client.chat.completions.create.call_args.kwargs
 
 
 def test_check_provider_available_returns_true_by_default(monkeypatch):
@@ -344,12 +311,7 @@ def test_check_provider_available_returns_true_by_default(monkeypatch):
 
 def test_has_openrouter_fallback_requires_openrouter_key(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    monkeypatch.delenv("CF_AIG_BASE_URL", raising=False)
     assert index.app_runtime.providers.has_openrouter_fallback() is False
 
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter_key")
-    monkeypatch.setenv(
-        "CF_AIG_BASE_URL", "https://gateway.ai.cloudflare.com/v1/acct/gw/groq"
-    )
-    monkeypatch.setenv("CF_AIG_TOKEN", "cf-token")
     assert index.app_runtime.providers.has_openrouter_fallback() is True

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -32,6 +32,43 @@ class _FakeClient:
         return self._responses.pop(0)
 
 
+def test_web_search_grounding_ignores_urls_from_other_tools():
+    from api.providers.runtime import ProviderRuntime
+
+    messages = [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "search_1",
+                    "type": "function",
+                    "function": {"name": "web_search", "arguments": "{}"},
+                },
+                {
+                    "id": "fetch_1",
+                    "type": "function",
+                    "function": {"name": "web_fetch", "arguments": "{}"},
+                },
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "search_1",
+            "content": '{"results":[]}',
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "fetch_1",
+            "content": '{"url":"https://example.com/not-a-search-result"}',
+        },
+    ]
+
+    assert not ProviderRuntime._answer_cites_web_search_source(
+        "Fuente: https://example.com/not-a-search-result",
+        messages,
+    )
+
+
 def test_provider_runtime_executes_tool_calls_until_stop():
     from api.ai.pricing import AIUsageResult
     from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -195,14 +195,14 @@ def test_provider_runtime_shares_web_search_budget_across_tool_rounds(
 
     assert result is not None
     assert result.metadata["web_search_requests"] == total_requests
-    assert client.calls[0]["tools"][0]["parameters"]["max_uses"] == 3
-    assert (
-        client.calls[1]["tools"][0]["parameters"]["max_uses"]
-        == second_max_uses
-    )
-    assert client.calls[1]["extra_body"] == {
-        "max_tool_calls": second_max_uses
-    }
+    assert client.calls[0]["tools"] == [
+        {"type": "function", "function": {"name": "calc"}}
+    ]
+    assert client.calls[1]["tools"] == [
+        {"type": "function", "function": {"name": "calc"}}
+    ]
+    assert "extra_body" not in client.calls[0]
+    assert "extra_body" not in client.calls[1]
 
 
 def test_provider_runtime_returns_text_when_tool_calls_are_unknown():
@@ -321,7 +321,7 @@ def test_provider_runtime_returns_plain_text_when_tools_never_called():
     assert result is not None
     assert result.text == "plain answer"
     assert_no_raw_tool_syntax(result.text)
-    assert client.calls[0]["tools"] == [{"type": "web_search"}, {"name": "calc"}]
+    assert client.calls[0]["tools"] == [{"name": "calc"}]
     execute_tool_fn.assert_not_called()
 
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -365,15 +365,28 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
 
 
 @pytest.mark.parametrize(
-    ("final_text", "expected_chunks", "grounded"),
+    ("final_text", "search_output", "expected_chunks", "grounded"),
     [
         (
             "Perfil: https://example.com/pablo",
+            '{"results":[{"title":"Pablo Wasserman",'
+            '"url":"https://example.com/pablo"}]}',
             ["Perfil: https://example.com/pablo"],
             True,
         ),
         (
             "La búsqueda falló y no encontré nada.",
+            '{"results":[{"title":"Pablo Wasserman",'
+            '"url":"https://example.com/pablo"}]}',
+            [
+                "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
+                "resultados citables; probá de nuevo en un momento."
+            ],
+            False,
+        ),
+        (
+            "Consulté https://example.com/not-a-result",
+            '{"query":"https://example.com/not-a-result","results":[]}',
             [
                 "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
                 "resultados citables; probá de nuevo en un momento."
@@ -384,6 +397,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
 )
 def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
     final_text,
+    search_output,
     expected_chunks,
     grounded,
 ):
@@ -451,12 +465,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
 
     client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
     execute_tool = MagicMock(
-        return_value=SimpleNamespace(
-            output=(
-                '{"results":[{"title":"Pablo Wasserman",'
-                '"url":"https://example.com/pablo"}]}'
-            )
-        )
+        return_value=SimpleNamespace(output=search_output)
     )
     usage_results = []
     search_schema = {
@@ -505,10 +514,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
     assert create_calls[1]["messages"][-1] == {
         "role": "tool",
         "tool_call_id": "search_1",
-        "content": (
-            '{"results":[{"title":"Pablo Wasserman",'
-            '"url":"https://example.com/pablo"}]}'
-        ),
+        "content": search_output,
     }
     assert usage_results[0].metadata["web_search_requests"] == 1
     assert usage_results[-1].metadata["web_search_grounded"] is grounded

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -256,7 +256,7 @@ def test_openrouter_stream_executes_fragmented_tool_call_and_reports_each_round(
         )
     )
 
-    assert chunks == ["resultado ", "final"]
+    assert chunks == ["resultado final"]
     assert_no_raw_tool_syntax("".join(chunks))
     execute_tool.assert_called_once_with(
         "calculate",
@@ -265,7 +265,13 @@ def test_openrouter_stream_executes_fragmented_tool_call_and_reports_each_round(
     )
     assert create_calls[0]["stream"] is True
     assert create_calls[1]["stream"] is True
-    assert create_calls[1]["tools"][0]["parameters"]["max_uses"] == 1
+    assert create_calls[0]["tools"] == [
+        {"type": "function", "function": {"name": "calculate"}}
+    ]
+    assert create_calls[1]["tools"] == [
+        {"type": "function", "function": {"name": "calculate"}}
+    ]
+    assert "extra_body" not in create_calls[1]
     assert create_calls[1]["messages"][-1] == {
         "role": "tool",
         "tool_call_id": "call_1",
@@ -316,7 +322,6 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
                 usage={
                     "prompt_tokens": 10,
                     "completion_tokens": 2,
-                    "server_tool_use": {"web_search_requests": 1},
                 },
             ),
         ])
@@ -343,16 +348,171 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             {"role": "system", "content": "sys"},
             [{"role": "user", "content": "hola"}],
             enable_web_search=True,
+            extra_tools=[
+                {"type": "function", "function": {"name": "web_search"}}
+            ],
             on_usage_result=usage_results.append,
         )
     )
 
-    assert chunks == ["web", " answer"]
+    assert chunks == ["web answer"]
     assert_no_raw_tool_syntax("".join(chunks))
-    assert create_calls[0]["tools"] == [{"type": "web_search"}]
-    assert usage_results[0].text.startswith("No pude verificar eso con fuentes")
-    assert usage_results[0].metadata["web_search_grounded"] is False
-    assert usage_results[0].metadata["stream_text_override"] == usage_results[0].text
+    assert create_calls[0]["tools"] == [
+        {"type": "function", "function": {"name": "web_search"}}
+    ]
+    assert usage_results[0].text == "web answer"
+    assert "web_search_grounded" not in usage_results[0].metadata
+
+
+@pytest.mark.parametrize(
+    ("final_text", "expected_chunks", "grounded"),
+    [
+        (
+            "Perfil: https://example.com/pablo",
+            ["Perfil: https://example.com/pablo"],
+            True,
+        ),
+        (
+            "La búsqueda falló y no encontré nada.",
+            [
+                "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
+                "resultados citables; probá de nuevo en un momento."
+            ],
+            False,
+        ),
+    ],
+)
+def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
+    final_text,
+    expected_chunks,
+    grounded,
+):
+    from types import SimpleNamespace
+
+    from api.ai.pricing import AIUsageResult
+    from api.providers.openrouter import OpenRouterProvider
+    from api.tools.runtime import ToolRuntime
+
+    create_calls = []
+    responses = [
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="tool_calls",
+                        delta=SimpleNamespace(
+                            content=None,
+                            annotations=[],
+                            tool_calls=[
+                                SimpleNamespace(
+                                    index=0,
+                                    id="search_1",
+                                    type="function",
+                                    function=SimpleNamespace(
+                                        name="web_search",
+                                        arguments='{"query":"Pablo Wasserman"}',
+                                    ),
+                                )
+                            ],
+                        ),
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage={"prompt_tokens": 10, "completion_tokens": 2},
+            ),
+        ],
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        delta=SimpleNamespace(
+                            content=final_text,
+                            annotations=[],
+                            tool_calls=[],
+                        ),
+                    )
+                ],
+                usage=None,
+            ),
+            SimpleNamespace(
+                choices=[],
+                usage={"prompt_tokens": 20, "completion_tokens": 4},
+            ),
+        ],
+    ]
+
+    def create(**kwargs):
+        create_calls.append(kwargs)
+        return iter(responses.pop(0))
+
+    client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    execute_tool = MagicMock(
+        return_value=SimpleNamespace(
+            output=(
+                '{"results":[{"title":"Pablo Wasserman",'
+                '"url":"https://example.com/pablo"}]}'
+            )
+        )
+    )
+    usage_results = []
+    search_schema = {
+        "type": "function",
+        "function": {"name": "web_search", "parameters": {"type": "object"}},
+    }
+    provider = OpenRouterProvider(
+        get_client=lambda: client,
+        admin_report=lambda *a, **k: None,
+        increment_request_count=lambda: None,
+        build_web_search_tool=lambda: {"type": "openrouter:web_search"},
+        build_usage_result=lambda **kwargs: AIUsageResult(
+            kind=kwargs["kind"],
+            text=kwargs["text"],
+            model=kwargs["model"],
+            usage=kwargs["response"].usage,
+            metadata=kwargs.get("metadata") or {},
+        ),
+        extract_usage_map=lambda response: response.usage,
+        primary_model="test-model",
+        tool_runtime=ToolRuntime(
+            execute_tool_fn=execute_tool,
+            tool_registry={"web_search": object()},
+            print_fn=lambda *_args: None,
+        ),
+    )
+
+    chunks = list(
+        provider.stream(
+            {"role": "system", "content": "sys"},
+            [{"role": "user", "content": "buscá a Pablo Wasserman"}],
+            enable_web_search=True,
+            extra_tools=[search_schema],
+            on_usage_result=usage_results.append,
+        )
+    )
+
+    assert chunks == expected_chunks
+    execute_tool.assert_called_once_with(
+        "web_search",
+        {"query": "Pablo Wasserman"},
+        {},
+    )
+    assert create_calls[0]["tools"] == [search_schema]
+    assert create_calls[1]["tools"] == [search_schema]
+    assert create_calls[1]["messages"][-1] == {
+        "role": "tool",
+        "tool_call_id": "search_1",
+        "content": (
+            '{"results":[{"title":"Pablo Wasserman",'
+            '"url":"https://example.com/pablo"}]}'
+        ),
+    }
+    assert usage_results[0].metadata["web_search_requests"] == 1
+    assert usage_results[-1].metadata["web_search_grounded"] is grounded
+    assert "web_search_requests" not in usage_results[-1].metadata
 
 
 def test_openrouter_stream_raises_on_provider_error_chunk():

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -1,0 +1,118 @@
+import json
+from unittest.mock import MagicMock
+
+import requests
+
+from api.tools.registry import execute_tool, get_all_tool_schemas
+from api.tools import web_search
+
+
+def _response(status_code, payload):
+    response = MagicMock()
+    response.status_code = status_code
+    response.ok = 200 <= status_code < 300
+    response.json.return_value = payload
+    response.text = json.dumps(payload)
+    return response
+
+
+def test_web_search_returns_compact_citable_results(monkeypatch):
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    post = MagicMock(
+        return_value=_response(
+            200,
+            {
+                "success": True,
+                "id": "search-1",
+                "creditsUsed": 1,
+                "data": {
+                    "web": [
+                        {
+                            "title": "Pablo Wasserman",
+                            "url": "https://example.com/pablo",
+                            "description": "Perfil público de Pablo Wasserman.",
+                            "markdown": "contenido largo que no debe enviarse",
+                        }
+                    ]
+                },
+            },
+        )
+    )
+    monkeypatch.setattr(web_search.requests, "post", post)
+
+    result = execute_tool("web_search", {"query": "Pablo Wasserman"})
+
+    payload = json.loads(result.output)
+    assert payload["results"] == [
+        {
+            "title": "Pablo Wasserman",
+            "url": "https://example.com/pablo",
+            "description": "Perfil público de Pablo Wasserman.",
+        }
+    ]
+    assert "markdown" not in result.output
+    assert result.metadata["result_count"] == 1
+    assert post.call_args.kwargs["json"] == {
+        "query": "Pablo Wasserman",
+        "limit": 5,
+        "sources": ["web"],
+        "timeout": 60_000,
+        "ignoreInvalidURLs": True,
+    }
+    assert post.call_args.kwargs["timeout"] == (10.0, 75.0)
+
+
+def test_web_search_retries_transient_http_failures(monkeypatch):
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    post = MagicMock(
+        side_effect=[
+            _response(500, {"success": False, "error": "temporary"}),
+            _response(200, {"success": True, "data": {"web": []}}),
+        ]
+    )
+    sleep = MagicMock()
+    monkeypatch.setattr(web_search.requests, "post", post)
+    monkeypatch.setattr(web_search.time, "sleep", sleep)
+
+    result = execute_tool("web_search", {"query": "consulta"})
+
+    assert json.loads(result.output)["results"] == []
+    assert post.call_count == 2
+    sleep.assert_called_once_with(1)
+
+
+def test_web_search_reports_timeout_after_retries(monkeypatch):
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    monkeypatch.setattr(
+        web_search.requests,
+        "post",
+        MagicMock(side_effect=requests.Timeout("slow")),
+    )
+    sleep = MagicMock()
+    monkeypatch.setattr(web_search.time, "sleep", sleep)
+
+    result = execute_tool("web_search", {"query": "consulta"})
+
+    assert result.output == "Error de búsqueda: Firecrawl agotó el tiempo de espera."
+    assert sleep.call_count == 2
+
+
+def test_web_search_schema_requires_key_and_enabled_context(monkeypatch):
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    names = {
+        tool["function"]["name"]
+        for tool in get_all_tool_schemas({"web_search_enabled": True})
+    }
+    assert "web_search" not in names
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    disabled_names = {
+        tool["function"]["name"]
+        for tool in get_all_tool_schemas({})
+    }
+    enabled_names = {
+        tool["function"]["name"]
+        for tool in get_all_tool_schemas({"web_search_enabled": True})
+    }
+    assert "web_search" not in disabled_names
+    assert "web_search" in enabled_names

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -57,7 +57,6 @@ def test_web_search_returns_compact_citable_results(monkeypatch):
         "limit": 5,
         "sources": ["web"],
         "timeout": 60_000,
-        "ignoreInvalidURLs": True,
     }
     assert post.call_args.kwargs["timeout"] == (10.0, 75.0)
 


### PR DESCRIPTION
## Summary

- replace OpenRouter-managed web search with an application-managed Firecrawl tool
- execute search through the existing streamed function-tool loop
- limit and normalize results, retry transient failures, and require source citations
- remove Cloudflare AI Gateway support and connect directly to OpenRouter and Groq

## Root cause

OpenRouter successfully invoked Firecrawl, but its opaque server-tool orchestration sometimes gave DeepSeek unusable results. The model then claimed that search failed even though Firecrawl marked each request as completed.

## Impact

The bot now receives and validates Firecrawl results directly. It can distinguish real HTTP failures from model claims, preserve source URLs, and prevent uncited failure hallucinations. Deployment requires `FIRECRAWL_API_KEY`; the old `CF_AIG_BASE_URL` and `CF_AIG_TOKEN` variables are no longer used.

## Validation

- `pytest -q` — 894 passed
- focused Ruff checks — passed
- focused strict mypy checks — passed
- `git diff --check` — passed