### PR TITLE
Fix successful web search responses

### DIFF
--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -224,15 +224,15 @@ class OpenRouterProvider(StreamingAIProvider):
                     )
                     continue
 
+                text_override = None
                 if total_web_search_requests > 0:
-                    web_metadata["web_search_grounded"] = (
-                        bool(web_metadata.get("web_search_citation_count"))
-                        or self._runtime._answer_cites_web_search_source(
-                            streamed_round.text,
-                            current_messages,
-                        )
+                    text_override = self._runtime._finalize_web_search_answer(
+                        streamed_round.text,
+                        current_messages,
+                        web_metadata,
+                        tool_context=tool_context,
+                        round_idx=round_idx,
                     )
-                text_override = self._runtime._stream_text_override(web_metadata)
                 if text_override is not None:
                     web_metadata["stream_text_override"] = text_override
                 self._report_stream_usage(

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -28,6 +28,8 @@ _UNGROUNDED_SEARCH_MESSAGE = (
     "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
     "resultados citables; probá de nuevo en un momento."
 )
+_MAX_WEB_SEARCH_SOURCES = 3
+_MAX_LOGGED_SEARCH_ANSWER_CHARS = 4_000
 _PSEUDO_TOOL_CALL_PATTERN = re.compile(
     r'^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\((?P<arguments>.*)\)\s*$',
     re.DOTALL,
@@ -699,12 +701,6 @@ class ProviderRuntime:
         return metadata
 
     @staticmethod
-    def _stream_text_override(metadata: Mapping[str, Any]) -> Optional[str]:
-        if metadata.get("web_search_grounded") is False:
-            return _UNGROUNDED_SEARCH_MESSAGE
-        return None
-
-    @staticmethod
     def _web_search_max_uses(tool: Mapping[str, Any]) -> int:
         parameters = ensure_mapping(tool.get("parameters")) or {}
         try:
@@ -814,9 +810,9 @@ class ProviderRuntime:
     def _web_search_source_urls(
         cls,
         current_messages: List[Dict[str, Any]],
-    ) -> set[str]:
+    ) -> list[str]:
         web_search_call_ids = cls._web_search_call_ids(current_messages)
-        source_urls: set[str] = set()
+        source_urls: list[str] = []
         for item in current_messages:
             if (
                 str(item.get("role") or "") != "tool"
@@ -833,21 +829,51 @@ class ProviderRuntime:
             for result_item in result_items:
                 result = ensure_mapping(result_item) or {}
                 source_url = str(result.get("url") or "").rstrip(".,);]")
-                if source_url:
-                    source_urls.add(source_url)
+                if source_url and source_url not in source_urls:
+                    source_urls.append(source_url)
         return source_urls
 
-    @classmethod
-    def _answer_cites_web_search_source(
-        cls,
+    def _finalize_web_search_answer(
+        self,
         text: str,
         current_messages: List[Dict[str, Any]],
-    ) -> bool:
-        cited_urls = {
-            url.rstrip(".,);]")
-            for url in re.findall(r"https?://[^\s\"<>]+", text)
-        }
-        return bool(cited_urls & cls._web_search_source_urls(current_messages))
+        metadata: Dict[str, Any],
+        *,
+        tool_context: Optional[Dict[str, Any]],
+        round_idx: int,
+    ) -> Optional[str]:
+        source_urls = self._web_search_source_urls(current_messages)
+        metadata["web_search_source_count"] = len(source_urls)
+        clean_text = text.strip()
+        if source_urls and clean_text:
+            selected_sources = source_urls[:_MAX_WEB_SEARCH_SOURCES]
+            missing_sources = [url for url in selected_sources if url not in text]
+            metadata["web_search_grounded"] = True
+            metadata["web_search_citation_count"] = len(selected_sources)
+            if not missing_sources:
+                return None
+            return f"{text.rstrip()}\n\nfuentes: {' '.join(missing_sources)}"
+
+        if metadata.get("web_search_citation_count") and clean_text:
+            metadata["web_search_grounded"] = True
+            return None
+
+        metadata["web_search_grounded"] = False
+        warning_context = dict(tool_context or {})
+        warning_context.update(
+            {
+                "model": self._deps.primary_model,
+                "tool_round": round_idx + 1,
+                "raw_answer_length": len(text),
+                **metadata,
+            }
+        )
+        logger.warning(
+            "openrouter: rejecting web-search answer raw_answer=%r%s",
+            text[:_MAX_LOGGED_SEARCH_ANSWER_CHARS],
+            format_log_context(warning_context),
+        )
+        return _UNGROUNDED_SEARCH_MESSAGE
 
     def _remaining_web_search_uses(
         self,
@@ -901,30 +927,16 @@ class ProviderRuntime:
             return ToolRoundDecision(updated_messages, continue_rounds=True)
 
         web_metadata = self._web_search_metadata(response, message)
+        text_override = None
         if total_web_search_requests > 0:
             web_metadata["web_search_requests"] = total_web_search_requests
-            web_metadata["web_search_grounded"] = (
-                bool(web_metadata.get("web_search_citation_count"))
-                or self._answer_cites_web_search_source(
-                    str(getattr(message, "content", "") or ""),
-                    current_messages,
-                )
+            text_override = self._finalize_web_search_answer(
+                str(getattr(message, "content", "") or ""),
+                current_messages,
+                web_metadata,
+                tool_context=tool_context,
+                round_idx=round_idx,
             )
-        text_override = None
-        if web_metadata.get("web_search_grounded") is False:
-            warning_context = dict(tool_context or {})
-            warning_context.update(
-                {
-                    "model": self._deps.primary_model,
-                    "tool_round": round_idx + 1,
-                    **web_metadata,
-                }
-            )
-            logger.warning(
-                "openrouter: suppressing ungrounded web-search answer%s",
-                format_log_context(warning_context),
-            )
-            text_override = _UNGROUNDED_SEARCH_MESSAGE
 
         return ToolRoundDecision(
             current_messages,

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -219,16 +219,19 @@ def test_provider_runtime_suppresses_web_search_answer_without_citations():
     client.chat.completions.create.return_value = response
     runtime = _build_provider_runtime(client=client)
 
-    result = runtime.complete(
-        {"role": "system", "content": "sys"},
-        [{"role": "user", "content": "busca la marca Oaaa"}],
-        enable_web_search=True,
-    )
+    with patch("api.providers.runtime.logger.warning") as warning:
+        result = runtime.complete(
+            {"role": "system", "content": "sys"},
+            [{"role": "user", "content": "busca la marca Oaaa"}],
+            enable_web_search=True,
+        )
 
     assert result is not None
     assert "No pude verificar eso con fuentes" in result.text
     assert result.metadata["web_search_grounded"] is False
     assert result.metadata["web_search_citation_count"] == 0
+    warning.assert_called_once()
+    assert warning.call_args.args[1] == "seguro existe esa marca"
 
 
 def test_provider_runtime_detects_pydantic_annotation():

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -32,7 +32,7 @@ class _FakeClient:
         return self._responses.pop(0)
 
 
-def test_web_search_grounding_ignores_urls_from_other_tools():
+def test_web_search_sources_ignore_urls_from_other_tools():
     from api.providers.runtime import ProviderRuntime
 
     messages = [
@@ -63,10 +63,103 @@ def test_web_search_grounding_ignores_urls_from_other_tools():
         },
     ]
 
-    assert not ProviderRuntime._answer_cites_web_search_source(
-        "Fuente: https://example.com/not-a-search-result",
-        messages,
+    assert ProviderRuntime._web_search_source_urls(messages) == []
+
+
+def test_provider_runtime_appends_sources_to_direct_search_answer():
+    from api.ai.pricing import AIUsageResult
+    from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps
+    from api.tools.runtime import ToolRuntime
+
+    search_call = SimpleNamespace(
+        id="search_1",
+        function=SimpleNamespace(
+            name="web_search",
+            arguments='{"query":"Juan Ruocco"}',
+        ),
     )
+    responses = [
+        _FakeResponse(
+            [
+                _FakeChoice(
+                    "tool_calls",
+                    SimpleNamespace(
+                        content="",
+                        tool_calls=[search_call],
+                        annotations=[],
+                    ),
+                )
+            ]
+        ),
+        _FakeResponse(
+            [
+                _FakeChoice(
+                    "stop",
+                    SimpleNamespace(
+                        content="juan ruocco es escritor y guionista",
+                        tool_calls=[],
+                        annotations=[],
+                    ),
+                )
+            ]
+        ),
+    ]
+    client = _FakeClient(responses)
+    tool_runtime = ToolRuntime(
+        execute_tool_fn=MagicMock(
+            return_value=SimpleNamespace(
+                output=(
+                    '{"results":['
+                    '{"url":"https://example.com/juan"},'
+                    '{"url":"https://example.com/entrevista"}]}'
+                )
+            )
+        ),
+        tool_registry={"web_search": object()},
+        print_fn=lambda *_args: None,
+    )
+    runtime = ProviderRuntime(
+        ProviderRuntimeDeps(
+            get_client=lambda: client,
+            admin_report=MagicMock(),
+            increment_request_count=MagicMock(),
+            build_web_search_tool=lambda: {
+                "type": "openrouter:web_search",
+                "parameters": {"max_uses": 3},
+            },
+            build_usage_result=lambda **kwargs: AIUsageResult(
+                kind=kwargs["kind"],
+                text=kwargs["text"],
+                model=kwargs["model"],
+                usage={},
+                metadata=kwargs.get("metadata") or {},
+            ),
+            extract_usage_map=lambda _response: {},
+            primary_model="test-model",
+            max_tool_rounds=5,
+        ),
+        tool_runtime,
+    )
+    search_schema = {
+        "type": "function",
+        "function": {"name": "web_search", "parameters": {"type": "object"}},
+    }
+
+    result = runtime.complete(
+        {"role": "system", "content": "sys"},
+        [{"role": "user", "content": "buscá a Juan Ruocco"}],
+        enable_web_search=True,
+        extra_tools=[search_schema],
+        tool_context={"web_search_enabled": True},
+    )
+
+    assert result is not None
+    assert result.text == (
+        "juan ruocco es escritor y guionista\n\nfuentes: "
+        "https://example.com/juan https://example.com/entrevista"
+    )
+    assert result.metadata["web_search_grounded"] is True
+    assert result.metadata["web_search_source_count"] == 2
 
 
 def test_provider_runtime_executes_tool_calls_until_stop():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -365,7 +365,13 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
 
 
 @pytest.mark.parametrize(
-    ("final_text", "search_output", "expected_chunks", "grounded"),
+    (
+        "final_text",
+        "search_output",
+        "expected_chunks",
+        "grounded",
+        "source_count",
+    ),
     [
         (
             "Perfil: https://example.com/pablo",
@@ -373,16 +379,18 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             '"url":"https://example.com/pablo"}]}',
             ["Perfil: https://example.com/pablo"],
             True,
+            1,
         ),
         (
             "La búsqueda falló y no encontré nada.",
             '{"results":[{"title":"Pablo Wasserman",'
             '"url":"https://example.com/pablo"}]}',
             [
-                "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
-                "resultados citables; probá de nuevo en un momento."
+                "La búsqueda falló y no encontré nada.\n\n"
+                "fuentes: https://example.com/pablo"
             ],
-            False,
+            True,
+            1,
         ),
         (
             "Consulté https://example.com/not-a-result",
@@ -392,6 +400,42 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
                 "resultados citables; probá de nuevo en un momento."
             ],
             False,
+            0,
+        ),
+        (
+            "encontré su perfil en https://www.instagram.com/realjuanruocco/",
+            '{"results":[{"title":"Juan Ruocco",'
+            '"url":"https://www.instagram.com/realjuanruocco/?hl=en"}]}',
+            [
+                "encontré su perfil en https://www.instagram.com/realjuanruocco/\n\n"
+                "fuentes: https://www.instagram.com/realjuanruocco/?hl=en"
+            ],
+            True,
+            1,
+        ),
+        (
+            "respuesta basada en los resultados",
+            '{"results":['
+            '{"url":"https://example.com/1"},'
+            '{"url":"https://example.com/2"},'
+            '{"url":"https://example.com/3"},'
+            '{"url":"https://example.com/4"}]}',
+            [
+                "respuesta basada en los resultados\n\nfuentes: "
+                "https://example.com/1 https://example.com/2 https://example.com/3"
+            ],
+            True,
+            4,
+        ),
+        (
+            "",
+            '{"results":[{"url":"https://example.com/pablo"}]}',
+            [
+                "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
+                "resultados citables; probá de nuevo en un momento."
+            ],
+            False,
+            1,
         ),
     ],
 )
@@ -400,6 +444,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
     search_output,
     expected_chunks,
     grounded,
+    source_count,
 ):
     from types import SimpleNamespace
 
@@ -518,6 +563,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
     }
     assert usage_results[0].metadata["web_search_requests"] == 1
     assert usage_results[-1].metadata["web_search_grounded"] is grounded
+    assert usage_results[-1].metadata["web_search_source_count"] == source_count
     assert "web_search_requests" not in usage_results[-1].metadata
 
 


### PR DESCRIPTION
## Summary

- keep usable model answers when Firecrawl returned results
- append up to three Firecrawl source URLs in stable result order
- reserve the generic search failure for real errors, empty results, or empty model answers
- log the raw model answer when the response is rejected

## Root cause

Production search completed successfully and returned five results, but DeepSeek did not copy an exact result URL into its answer. The citation gate treated that formatting difference as a search failure and replaced the whole answer with the generic failure message.

## Impact

Successful searches no longer appear to fail because the model omitted a URL or normalized it differently, such as removing query parameters. Both streaming and non-streaming responses now include deterministic source links.

## Validation

- `pytest -q` — 900 passed
- focused Ruff checks — passed
- focused strict mypy checks — passed
- `git diff --check` — passed