### PR TITLE
Anonymize test fixtures

### DIFF
--- a/tests/test_ai_requests.py
+++ b/tests/test_ai_requests.py
@@ -88,7 +88,7 @@ def test_build_ai_messages_includes_links_context():
     message = {
         "from": {"first_name": "Ana", "username": "ana"},
         "chat": {"type": "private", "title": None},
-        "text": "mirá fixupx.com/status/2032173338240467235",
+        "text": "mirá fixupx.com/status/1234567890123456789",
     }
 
     with (
@@ -97,7 +97,7 @@ def test_build_ai_messages_includes_links_context():
             index._link_service,
             "fetch_metadata",
             return_value={
-                "url": "https://fixupx.com/status/2032173338240467235",
+                "url": "https://fixupx.com/status/1234567890123456789",
                 "title": "tweet",
                 "description": "contenido",
             },
@@ -107,7 +107,7 @@ def test_build_ai_messages_includes_links_context():
 
     content = messages[0]["content"]
     assert "LINKS DEL MENSAJE:" in content
-    assert "https://fixupx.com/status/2032173338240467235" in content
+    assert "https://fixupx.com/status/1234567890123456789" in content
     assert "titulo: tweet" in content
     assert "descripcion: contenido" in content
 

--- a/tests/test_command_routing.py
+++ b/tests/test_command_routing.py
@@ -73,7 +73,7 @@ def test_tasks_command_shows_cron_frequency():
             {
                 "id": "63dce153",
                 "text": "decime cuanta aura farmeaste hoy",
-                "user_name": "@astrolince",
+                "user_name": "@test_user",
                 "interval_seconds": None,
                 "trigger_config": {"type": "cron", "hour": 20, "minute": 30},
                 "next_run": "17/04 20:30",

--- a/tests/test_link_pipeline.py
+++ b/tests/test_link_pipeline.py
@@ -104,12 +104,12 @@ def test_extract_message_urls_prefers_entities_and_limits_to_three():
 
 def test_extract_message_urls_detects_bare_domains_without_scheme():
     message = {
-        "text": "mirá fixupx.com/status/2032173338240467235, después vemos",
+        "text": "mirá fixupx.com/status/1234567890123456789, después vemos",
         "entities": [],
     }
 
     assert link_service.extract_message_urls(message) == [
-        "https://fixupx.com/status/2032173338240467235"
+        "https://fixupx.com/status/1234567890123456789"
     ]
 
 
@@ -142,17 +142,17 @@ def test_build_message_links_context_keeps_full_youtube_transcript():
         patch.object(
             link_service,
             "extract_message_urls",
-            return_value=["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+            return_value=["https://www.youtube.com/watch?v=EXAMPLE1234"],
         ),
         patch.object(
             link_service,
             "fetch_metadata",
-            return_value={"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"},
+            return_value={"url": "https://www.youtube.com/watch?v=EXAMPLE1234"},
         ),
         patch.object(link_service, "fetch_transcript", return_value=transcript),
     ):
         context = link_service.build_context(
-            {"text": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"}
+            {"text": "https://www.youtube.com/watch?v=EXAMPLE1234"}
         )
 
     assert transcript in context
@@ -244,7 +244,7 @@ def test_fetch_link_metadata_uses_ttl_constant():
 def test_can_embed_url_primes_link_metadata_cache():
     html_body = (
         "<html><head>"
-        '<meta property="og:title" content="Agustin Cortes (@agucortes)" />'
+        '<meta property="og:title" content="Example User (@test_user)" />'
         '<meta property="og:description" content="Texto del post" />'
         '<meta name="twitter:card" content="tweet" />'
         "</head></html>"
@@ -253,7 +253,7 @@ def test_can_embed_url_primes_link_metadata_cache():
     embed_response.status_code = 200
     embed_response.headers = {"Content-Type": "text/html; charset=utf-8"}
     embed_response.text = html_body
-    embed_response.url = "https://fixupx.com/status/2032173338240467235"
+    embed_response.url = "https://fixupx.com/status/1234567890123456789"
 
     class R:
         def __init__(self):
@@ -277,14 +277,14 @@ def test_can_embed_url_primes_link_metadata_cache():
         return_value=embed_response,
     ):
         assert service.can_embed(
-            "https://fixupx.com/status/2032173338240467235"
+            "https://fixupx.com/status/1234567890123456789"
         ) is True
 
     result = service.fetch_metadata(
-        "https://fixupx.com/status/2032173338240467235"
+        "https://fixupx.com/status/1234567890123456789"
     )
 
-    assert result["title"] == "Agustin Cortes (@agucortes)"
+    assert result["title"] == "Example User (@test_user)"
     assert result["description"] == "Texto del post"
     service.request_fn.assert_not_called()
 
@@ -295,20 +295,20 @@ def test_build_message_links_context_uses_tweet_content_before_generic_metadata(
             link_service,
             "fetch_tweet_content",
             return_value={
-                "url": "https://x.com/sentdefender/status/2048202539770802483",
-                "author": "OSINTdefender",
-                "date": "Apr 26, 2026",
-                "text": "Reports of shots fired were unfounded.",
+                "url": "https://x.com/test_user/status/1234567890123456789",
+                "author": "Example User",
+                "date": "Jan 1, 2020",
+                "text": "This is an example status update.",
             },
         ) as mock_tweet,
         patch.object(link_service, "fetch_metadata") as mock_metadata,
     ):
         context = link_service.build_context(
-            {"text": "https://fixupx.com/status/2048202539770802483"}
+            {"text": "https://fixupx.com/status/1234567890123456789"}
         )
 
-    assert "https://x.com/sentdefender/status/2048202539770802483" in context
-    assert "autor: OSINTdefender" in context
-    assert "tweet: Reports of shots fired were unfounded." in context
-    mock_tweet.assert_called_once_with("https://fixupx.com/status/2048202539770802483")
+    assert "https://x.com/test_user/status/1234567890123456789" in context
+    assert "autor: Example User" in context
+    assert "tweet: This is an example status update." in context
+    mock_tweet.assert_called_once_with("https://fixupx.com/status/1234567890123456789")
     mock_metadata.assert_not_called()

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -48,7 +48,7 @@ def test_replace_links(mock_get, _mock_time):
     text = (
         "Check https://twitter.com/foo?utm_source=share and http://x.com/bar?s=20 and https://bsky.app/baz?share=1 and "
         "https://www.instagram.com/qux?igsh=abc123 and https://www.reddit.com/r/foo?st=abc and https://old.reddit.com/r/bar?utm_name=bar and "
-        "https://www.tiktok.com/@bar?lang=en and https://vm.tiktok.com/ZMHGacxknMW5J-gEiNC/?share=copy"
+        "https://www.tiktok.com/@bar?lang=en and https://vm.tiktok.com/EXAMPLE_VIDEO/?share=copy"
     )
     fixed, changed, originals = replace_links(text)
     assert changed
@@ -59,7 +59,7 @@ def test_replace_links(mock_get, _mock_time):
     assert "https://www.rxddit.com/r/foo" in fixed
     assert "https://old.rxddit.com/r/bar" in fixed
     assert "https://www.tiktok.com/@bar" in fixed
-    assert "https://vm.tiktok.com/ZMHGacxknMW5J-gEiNC/" in fixed
+    assert "https://vm.tiktok.com/EXAMPLE_VIDEO/" in fixed
     assert "fxtwitter.com" not in fixed
     assert "fixupx.com" not in fixed
     assert "utm_" not in fixed
@@ -504,13 +504,13 @@ def test_replace_links_strips_xcom_i_status():
 
     mock_can = MagicMock(return_value=True)
     text, changed, originals = links_replace_links(
-        "https://x.com/i/status/1848434048944783554",
+        "https://x.com/i/status/1234567890123456789",
         embed_checker=mock_can,
     )
-    assert text == "https://fixupx.com/status/1848434048944783554"
+    assert text == "https://fixupx.com/status/1234567890123456789"
     assert changed is True
-    assert originals == ["https://x.com/i/status/1848434048944783554"]
-    mock_can.assert_called_once_with("https://fixupx.com/status/1848434048944783554")
+    assert originals == ["https://x.com/i/status/1234567890123456789"]
+    mock_can.assert_called_once_with("https://fixupx.com/status/1234567890123456789")
 
 
 def test_replace_links_skips_twitter_user_profiles():
@@ -628,14 +628,14 @@ def test_can_embed_url_allows_twitter_card_text_preview(monkeypatch):
     mock_response.headers = {"Content-Type": "text/html"}
     mock_response.text = (
         "<meta name='twitter:card' content='tweet'>"
-        "<meta name='twitter:title' content='Agustin Cortes (@agucortes)'>"
+        "<meta name='twitter:title' content='Example User (@test_user)'>"
         "<meta property='og:description' content='Texto del post'>"
     )
     monkeypatch.setattr(
         "api.utils.links.request_with_ssl_fallback", lambda *a, **kw: mock_response
     )
 
-    assert can_embed_url("https://fixupx.com/status/2032173338240467235") is True
+    assert can_embed_url("https://fixupx.com/status/1234567890123456789") is True
 
 
 def test_can_embed_url_rejects_twitter_card_only(monkeypatch):
@@ -680,7 +680,7 @@ def test_can_embed_url_falls_back_to_get_when_eeinstagram_head_not_allowed(monke
 
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
 
-    assert can_embed_url("https://eeinstagram.com/reel/DUEZt-wEXNw/") is True
+    assert can_embed_url("https://eeinstagram.com/reel/EXAMPLE_REEL/") is True
 
 
 def test_can_embed_url_allows_eeinstagram_image_only_metadata(monkeypatch):
@@ -708,7 +708,7 @@ def test_can_embed_url_allows_eeinstagram_image_only_metadata(monkeypatch):
 
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
 
-    assert can_embed_url("https://eeinstagram.com/p/DVUqOBgDEor/") is True
+    assert can_embed_url("https://eeinstagram.com/p/EXAMPLE_POST/") is True
 
 
 def test_can_embed_url_retries_eeinstagram_get_transient_status(monkeypatch):
@@ -745,7 +745,7 @@ def test_can_embed_url_retries_eeinstagram_get_transient_status(monkeypatch):
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
     monkeypatch.setattr("api.utils.links.time.sleep", sleep_calls.append)
 
-    assert can_embed_url("https://eeinstagram.com/reel/DUEZt-wEXNw/") is True
+    assert can_embed_url("https://eeinstagram.com/reel/EXAMPLE_REEL/") is True
     assert sleep_calls == [0.25]
 
 
@@ -773,7 +773,7 @@ def test_can_embed_url_retries_eeinstagram_head_exception(monkeypatch):
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
     monkeypatch.setattr("api.utils.links.time.sleep", sleep_calls.append)
 
-    assert can_embed_url("https://eeinstagram.com/reel/DUEZt-wEXNw/") is True
+    assert can_embed_url("https://eeinstagram.com/reel/EXAMPLE_REEL/") is True
     assert calls["head"] == 2
     assert sleep_calls == [0.25]
 
@@ -808,7 +808,7 @@ def test_can_embed_url_falls_back_to_get_when_eeinstagram_head_retries_exhausted
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
     monkeypatch.setattr("api.utils.links.time.sleep", sleep_calls.append)
 
-    assert can_embed_url("https://eeinstagram.com/reel/DUEZt-wEXNw/") is True
+    assert can_embed_url("https://eeinstagram.com/reel/EXAMPLE_REEL/") is True
     assert calls == {"head": 3, "get": 2}
     assert sleep_calls == [0.25, 0.5]
 
@@ -845,7 +845,7 @@ def test_can_embed_url_falls_back_to_get_when_eeinstagram_head_5xx_exhausted(
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
     monkeypatch.setattr("api.utils.links.time.sleep", sleep_calls.append)
 
-    assert can_embed_url("https://eeinstagram.com/reel/DUEZt-wEXNw/") is True
+    assert can_embed_url("https://eeinstagram.com/reel/EXAMPLE_REEL/") is True
     assert calls == {"head": 3, "get": 2}
     assert sleep_calls == [0.25, 0.5]
 
@@ -866,7 +866,7 @@ def test_can_embed_url_allows_eeinstagram_redirect(monkeypatch):
 
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
 
-    assert can_embed_url("https://eeinstagram.com/reel/DOmco1zjuVi/") is True
+    assert can_embed_url("https://eeinstagram.com/reel/EXAMPLE_ALT/") is True
 
 
 def test_can_embed_url_allows_eeinstagram_post_redirect(monkeypatch):
@@ -885,7 +885,7 @@ def test_can_embed_url_allows_eeinstagram_post_redirect(monkeypatch):
 
     monkeypatch.setattr("api.utils.links.request_with_ssl_fallback", fake_request)
 
-    assert can_embed_url("https://eeinstagram.com/p/DQ5RaKnjE8J/") is True
+    assert can_embed_url("https://eeinstagram.com/p/EXAMPLE_ALT/") is True
 
 
 @patch("api.utils.links.request_with_ssl_fallback")

--- a/tests/test_memory_compaction.py
+++ b/tests/test_memory_compaction.py
@@ -210,10 +210,10 @@ def test_fetch_chat_messages_for_compaction_uses_tag_only_query():
     redis_client = MagicMock()
     redis_client.execute_command.side_effect = [[0], [0]]
 
-    fetch_chat_messages_for_compaction(redis_client, "5162530")
+    fetch_chat_messages_for_compaction(redis_client, "123456789")
 
     query = redis_client.execute_command.call_args.args[2]
-    assert query == "@chat_id:{5162530}"
+    assert query == "@chat_id:{123456789}"
     assert "*" not in query
 
 

--- a/tests/test_message_ai_media.py
+++ b/tests/test_message_ai_media.py
@@ -339,7 +339,7 @@ def test_handle_msg_command_reply_to_link_fix_message_is_not_blocked(monkeypatch
         "reply_to_message": {
             "message_id": 200,
             "from": {"username": "testbot"},
-            "text": "https://fixupx.com/status/2032173338240467235",
+            "text": "https://fixupx.com/status/1234567890123456789",
         },
     }
 

--- a/tests/test_message_routing.py
+++ b/tests/test_message_routing.py
@@ -557,8 +557,8 @@ def test_message_handler_stores_user_message_when_bot_should_not_respond(monkeyp
     [
         (
             "private",
-            "https://www.instagram.com/reel/DYcbT4OBtyZ/",
-            "Ana: https://www.instagram.com/reel/DYcbT4OBtyZ/",
+            "https://www.instagram.com/reel/EXAMPLE_REEL/",
+            "Ana: https://www.instagram.com/reel/EXAMPLE_REEL/",
         ),
         (
             "group",
@@ -687,9 +687,9 @@ def test_message_handler_replaces_plain_link_reply_to_bot(monkeypatch):
     make_deps, redis_client = _build_message_handler_deps()
     link_service = MagicMock()
     link_service.replace.return_value = (
-        "https://fixupx.com/status/2071194631480414436",
+        "https://fixupx.com/status/1234567890123456789",
         True,
-        ["https://x.com/i/status/2071194631480414436"],
+        ["https://x.com/i/status/1234567890123456789"],
     )
     link_service.build_context.return_value = ""
     link_service.download_oversized_instagram_video.return_value = None
@@ -699,31 +699,31 @@ def test_message_handler_replaces_plain_link_reply_to_bot(monkeypatch):
     message = {
         "message_id": 506,
         "chat": {"id": 562, "type": "group"},
-        "from": {"id": 1008, "first_name": "Profe", "username": "profe"},
+        "from": {"id": 1008, "first_name": "Test", "username": "test_user"},
         "reply_to_message": {
             "message_id": 405,
             "from": {"username": "testbot"},
-            "text": "https://kkinstagram.com/reel/DaHY1E7Ar9d/?tg=495182",
+            "text": "https://kkinstagram.com/reel/EXAMPLE_REEL/?tg=123456",
         },
-        "text": "https://x.com/i/status/2071194631480414436",
+        "text": "https://x.com/i/status/1234567890123456789",
     }
 
     result = handle_msg(message, deps)
 
     assert result == "ok"
     link_service.replace.assert_called_once_with(
-        "https://x.com/i/status/2071194631480414436"
+        "https://x.com/i/status/1234567890123456789"
     )
     deps.send_msg.assert_called_once_with(
         "562",
-        "https://fixupx.com/status/2071194631480414436\n\ncompartido por @profe",
+        "https://fixupx.com/status/1234567890123456789\n\ncompartido por @test_user",
         "405",
-        ["https://x.com/i/status/2071194631480414436"],
+        ["https://x.com/i/status/1234567890123456789"],
     )
     deps.save_message_to_redis.assert_called_once_with(
         "562",
         "bot_999",
-        "https://fixupx.com/status/2071194631480414436\n\ncompartido por @profe",
+        "https://fixupx.com/status/1234567890123456789\n\ncompartido por @test_user",
         redis_client,
     )
     deps.handle_ai_stream.assert_not_called()

--- a/tests/test_message_state.py
+++ b/tests/test_message_state.py
@@ -291,7 +291,7 @@ def test_search_chat_history_escapes_negative_group_chat_id():
 def test_escape_search_text_escapes_at_sign():
     from api.memory.state import _escape_search_text
 
-    assert _escape_search_text("@playtimbabot") == "\\@playtimbabot"
+    assert _escape_search_text("@test_bot") == "\\@test_bot"
     assert _escape_search_text("hello @user world") == "hello \\@user world"
     assert _escape_search_text("no at sign here") == "no at sign here"
 
@@ -306,14 +306,14 @@ def test_search_chat_history_escapes_at_sign_in_query():
 
     search_chat_history(
         redis_client,
-        chat_id="-1002201300982",
-        query_text="explica que es el trading de futuros y porque esa chica dice que perdió sus ahorros por no saber operar sin medir el riesgo, y porque eso no tiene nada que ver con perder la guita en el coinflip de @playtimbabot",
+        chat_id="-1001234567890",
+        query_text="explica que es el trading de futuros y porque esa chica dice que perdió sus ahorros por no saber operar sin medir el riesgo, y porque eso no tiene nada que ver con perder la guita en el coinflip de @test_bot",
         limit=5,
     )
 
     query = redis_client.execute_command.call_args_list[1].args[2]
-    assert "\\@playtimbabot" in query
-    assert "@chat_id:{\\-1002201300982}" in query
+    assert "\\@test_bot" in query
+    assert "@chat_id:{\\-1001234567890}" in query
 
 
 def test_truncate_text_more_edge_cases():

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -222,7 +222,7 @@ def test_provider_runtime_suppresses_web_search_answer_without_citations():
     with patch("api.providers.runtime.logger.warning") as warning:
         result = runtime.complete(
             {"role": "system", "content": "sys"},
-            [{"role": "user", "content": "busca la marca Oaaa"}],
+            [{"role": "user", "content": "busca la marca Ejemplo"}],
             enable_web_search=True,
         )
 

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -75,7 +75,7 @@ def test_provider_runtime_appends_sources_to_direct_search_answer():
         id="search_1",
         function=SimpleNamespace(
             name="web_search",
-            arguments='{"query":"Juan Ruocco"}',
+            arguments='{"query":"Autor Ejemplo"}',
         ),
     )
     responses = [
@@ -96,7 +96,7 @@ def test_provider_runtime_appends_sources_to_direct_search_answer():
                 _FakeChoice(
                     "stop",
                     SimpleNamespace(
-                        content="juan ruocco es escritor y guionista",
+                        content="autor ejemplo es escritor y guionista",
                         tool_calls=[],
                         annotations=[],
                     ),
@@ -110,8 +110,8 @@ def test_provider_runtime_appends_sources_to_direct_search_answer():
             return_value=SimpleNamespace(
                 output=(
                     '{"results":['
-                    '{"url":"https://example.com/juan"},'
-                    '{"url":"https://example.com/entrevista"}]}'
+                    '{"url":"https://example.com/profile"},'
+                    '{"url":"https://example.com/interview"}]}'
                 )
             )
         ),
@@ -147,7 +147,7 @@ def test_provider_runtime_appends_sources_to_direct_search_answer():
 
     result = runtime.complete(
         {"role": "system", "content": "sys"},
-        [{"role": "user", "content": "buscá a Juan Ruocco"}],
+        [{"role": "user", "content": "buscá a Autor Ejemplo"}],
         enable_web_search=True,
         extra_tools=[search_schema],
         tool_context={"web_search_enabled": True},
@@ -155,8 +155,8 @@ def test_provider_runtime_appends_sources_to_direct_search_answer():
 
     assert result is not None
     assert result.text == (
-        "juan ruocco es escritor y guionista\n\nfuentes: "
-        "https://example.com/juan https://example.com/entrevista"
+        "autor ejemplo es escritor y guionista\n\nfuentes: "
+        "https://example.com/profile https://example.com/interview"
     )
     assert result.metadata["web_search_grounded"] is True
     assert result.metadata["web_search_source_count"] == 2
@@ -613,7 +613,7 @@ def test_provider_runtime_executes_dsml_pseudo_web_fetch_call():
                         "<｜｜DSML｜｜tool_calls>\n"
                         '<｜｜DSML｜｜invoke name="web_fetch">\n'
                         '<｜｜DSML｜｜parameter name="url" string="true">'
-                        "https://nitter.net/deptofwar/status/2052723504336736284"
+                        "https://nitter.net/test_account/status/1234567890123456789"
                         "</｜｜DSML｜｜parameter>\n"
                         "</｜｜DSML｜｜invoke>\n"
                         "</｜｜DSML｜｜tool_calls>"
@@ -671,7 +671,7 @@ def test_provider_runtime_executes_dsml_pseudo_web_fetch_call():
     assert_no_raw_tool_syntax(result.text)
     execute_tool_fn.assert_called_once_with(
         "web_fetch",
-        {"url": "https://nitter.net/deptofwar/status/2052723504336736284"},
+        {"url": "https://nitter.net/test_account/status/1234567890123456789"},
         {"chat_id": "123"},
     )
 

--- a/tests/test_runtime_wiring.py
+++ b/tests/test_runtime_wiring.py
@@ -42,7 +42,7 @@ def test_index_tasks_command_formats_real_runtime_task_rows(monkeypatch):
             {
                 "id": "abc123",
                 "text": "recordame algo",
-                "user_name": "@astro",
+                "user_name": "@test_admin",
                 "interval_seconds": None,
                 "trigger_config": None,
                 "next_run": "17/04 22:04",

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -374,20 +374,20 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
     ),
     [
         (
-            "Perfil: https://example.com/pablo",
-            '{"results":[{"title":"Pablo Wasserman",'
-            '"url":"https://example.com/pablo"}]}',
-            ["Perfil: https://example.com/pablo"],
+            "Perfil: https://example.com/profile",
+            '{"results":[{"title":"Persona Ejemplo",'
+            '"url":"https://example.com/profile"}]}',
+            ["Perfil: https://example.com/profile"],
             True,
             1,
         ),
         (
             "La búsqueda falló y no encontré nada.",
-            '{"results":[{"title":"Pablo Wasserman",'
-            '"url":"https://example.com/pablo"}]}',
+            '{"results":[{"title":"Persona Ejemplo",'
+            '"url":"https://example.com/profile"}]}',
             [
                 "La búsqueda falló y no encontré nada.\n\n"
-                "fuentes: https://example.com/pablo"
+                "fuentes: https://example.com/profile"
             ],
             True,
             1,
@@ -403,12 +403,12 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             0,
         ),
         (
-            "encontré su perfil en https://www.instagram.com/realjuanruocco/",
-            '{"results":[{"title":"Juan Ruocco",'
-            '"url":"https://www.instagram.com/realjuanruocco/?hl=en"}]}',
+            "encontré su perfil en https://social.example/perfil/",
+            '{"results":[{"title":"Persona Ejemplo",'
+            '"url":"https://social.example/perfil/?lang=es"}]}',
             [
-                "encontré su perfil en https://www.instagram.com/realjuanruocco/\n\n"
-                "fuentes: https://www.instagram.com/realjuanruocco/?hl=en"
+                "encontré su perfil en https://social.example/perfil/\n\n"
+                "fuentes: https://social.example/perfil/?lang=es"
             ],
             True,
             1,
@@ -429,7 +429,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
         ),
         (
             "",
-            '{"results":[{"url":"https://example.com/pablo"}]}',
+            '{"results":[{"url":"https://example.com/profile"}]}',
             [
                 "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
                 "resultados citables; probá de nuevo en un momento."
@@ -469,7 +469,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
                                     type="function",
                                     function=SimpleNamespace(
                                         name="web_search",
-                                        arguments='{"query":"Pablo Wasserman"}',
+                                        arguments='{"query":"Persona Ejemplo"}',
                                     ),
                                 )
                             ],
@@ -541,7 +541,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
     chunks = list(
         provider.stream(
             {"role": "system", "content": "sys"},
-            [{"role": "user", "content": "buscá a Pablo Wasserman"}],
+            [{"role": "user", "content": "buscá a Persona Ejemplo"}],
             enable_web_search=True,
             extra_tools=[search_schema],
             on_usage_result=usage_results.append,
@@ -551,7 +551,7 @@ def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
     assert chunks == expected_chunks
     execute_tool.assert_called_once_with(
         "web_search",
-        {"query": "Pablo Wasserman"},
+        {"query": "Persona Ejemplo"},
         {},
     )
     assert create_calls[0]["tools"] == [search_schema]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -103,23 +103,23 @@ class TestWebFetchTool:
     @patch("api.utils.links.fetch_tweet_via_oembed")
     def test_web_fetch_reads_tweet_with_oembed(self, mock_oembed):
         mock_oembed.return_value = {
-            "author_name": "OSINTdefender",
+            "author_name": "Example User",
             "html": (
-                "<blockquote><p>Reports of shots fired were unfounded.</p>"
-                "<a href='https://x.com/sentdefender/status/2048202539770802483'>"
-                "Apr 26, 2026</a></blockquote>"
+                "<blockquote><p>This is an example status update.</p>"
+                "<a href='https://x.com/test_user/status/1234567890123456789'>"
+                "Jan 1, 2020</a></blockquote>"
             ),
         }
 
         result = execute_tool(
             "web_fetch",
-            {"url": "https://x.com/sentdefender/status/2048202539770802483"},
+            {"url": "https://x.com/test_user/status/1234567890123456789"},
             {},
         )
 
-        assert "OSINTdefender" in result.output
-        assert "Reports of shots fired" in result.output
-        assert result.metadata["url"] == "https://x.com/sentdefender/status/2048202539770802483"
+        assert "Example User" in result.output
+        assert "example status update" in result.output
+        assert result.metadata["url"] == "https://x.com/test_user/status/1234567890123456789"
 
     @patch("api.utils.links.request_with_ssl_fallback")
     @patch("api.utils.links.fetch_tweet_via_oembed")
@@ -129,27 +129,27 @@ class TestWebFetchTool:
         mock_response = MagicMock()
         mock_response.status_code = 200
         mock_response.headers = {"Content-Type": "text/html"}
-        mock_response.url = "https://fixupx.com/status/2048202539770802483"
+        mock_response.url = "https://fixupx.com/status/1234567890123456789"
         mock_response.text = (
-            "<meta property='og:url' content='https://x.com/sentdefender/status/2048202539770802483'>"
-            "<meta property='og:title' content='OSINTdefender (@sentdefender)'>"
+            "<meta property='og:url' content='https://x.com/test_user/status/1234567890123456789'>"
+            "<meta property='og:title' content='Example User (@test_user)'>"
             "<meta property='og:description' content='Following reports'>"
             "<meta property='og:image' content='https://example.com/image.jpg'>"
         )
         mock_request.return_value = mock_response
         mock_oembed.return_value = {
-            "author_name": "OSINTdefender",
+            "author_name": "Example User",
             "html": "<blockquote><p>All clear.</p></blockquote>",
         }
 
         result = execute_tool(
             "web_fetch",
-            {"url": "https://fixupx.com/status/2048202539770802483"},
+            {"url": "https://fixupx.com/status/1234567890123456789"},
             {},
         )
 
         assert "All clear" in result.output
-        assert result.metadata["url"] == "https://x.com/sentdefender/status/2048202539770802483"
+        assert result.metadata["url"] == "https://x.com/test_user/status/1234567890123456789"
 
     @patch("api.links.agent_tools.fetch_url_content")
     def test_web_fetch_rejects_x_error_page(self, mock_fetch):

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -28,9 +28,9 @@ def test_web_search_returns_compact_citable_results(monkeypatch):
                 "data": {
                     "web": [
                         {
-                            "title": "Pablo Wasserman",
-                            "url": "https://example.com/pablo",
-                            "description": "Perfil público de Pablo Wasserman.",
+                            "title": "Persona Ejemplo",
+                            "url": "https://example.com/profile",
+                            "description": "Perfil público de Persona Ejemplo.",
                             "markdown": "contenido largo que no debe enviarse",
                         }
                     ]
@@ -40,20 +40,20 @@ def test_web_search_returns_compact_citable_results(monkeypatch):
     )
     monkeypatch.setattr(web_search.requests, "post", post)
 
-    result = execute_tool("web_search", {"query": "Pablo Wasserman"})
+    result = execute_tool("web_search", {"query": "Persona Ejemplo"})
 
     payload = json.loads(result.output)
     assert payload["results"] == [
         {
-            "title": "Pablo Wasserman",
-            "url": "https://example.com/pablo",
-            "description": "Perfil público de Pablo Wasserman.",
+            "title": "Persona Ejemplo",
+            "url": "https://example.com/profile",
+            "description": "Perfil público de Persona Ejemplo.",
         }
     ]
     assert "markdown" not in result.output
     assert result.metadata["result_count"] == 1
     assert post.call_args.kwargs["json"] == {
-        "query": "Pablo Wasserman",
+        "query": "Persona Ejemplo",
         "limit": 5,
         "sources": ["web"],
         "timeout": 60_000,

--- a/tests/test_youtube_transcript.py
+++ b/tests/test_youtube_transcript.py
@@ -11,37 +11,37 @@ from api.utils.youtube_transcript import (
 class TestExtractVideoId:
     def test_standard_watch_url(self):
         assert (
-            extract_youtube_video_id("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-            == "dQw4w9WgXcQ"
+            extract_youtube_video_id("https://www.youtube.com/watch?v=EXAMPLE1234")
+            == "EXAMPLE1234"
         )
 
     def test_short_youtu_be_url(self):
-        assert extract_youtube_video_id("https://youtu.be/dQw4w9WgXcQ") == "dQw4w9WgXcQ"
+        assert extract_youtube_video_id("https://youtu.be/EXAMPLE1234") == "EXAMPLE1234"
 
     def test_embedded_url(self):
         assert (
-            extract_youtube_video_id("https://www.youtube.com/embed/dQw4w9WgXcQ")
-            == "dQw4w9WgXcQ"
+            extract_youtube_video_id("https://www.youtube.com/embed/EXAMPLE1234")
+            == "EXAMPLE1234"
         )
 
     def test_short_url(self):
         assert (
-            extract_youtube_video_id("https://youtube.com/shorts/dQw4w9WgXcQ")
-            == "dQw4w9WgXcQ"
+            extract_youtube_video_id("https://youtube.com/shorts/EXAMPLE1234")
+            == "EXAMPLE1234"
         )
 
     def test_youtube_url_with_extra_params(self):
         assert (
             extract_youtube_video_id(
-                "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+                "https://www.youtube.com/watch?v=EXAMPLE1234&list=PLAYLIST_EXAMPLE"
             )
-            == "dQw4w9WgXcQ"
+            == "EXAMPLE1234"
         )
 
     def test_mobile_url(self):
         assert (
-            extract_youtube_video_id("https://m.youtube.com/watch?v=dQw4w9WgXcQ")
-            == "dQw4w9WgXcQ"
+            extract_youtube_video_id("https://m.youtube.com/watch?v=EXAMPLE1234")
+            == "EXAMPLE1234"
         )
 
     def test_no_url_returns_none(self):
@@ -111,12 +111,12 @@ class TestFetchYouTubeTranscript:
         mock_transcript_list.find_transcript.return_value = mock_transcript
         mock_yta_instance.list.return_value = mock_transcript_list
 
-        transcript, error = fetch_youtube_transcript("dQw4w9WgXcQ")
+        transcript, error = fetch_youtube_transcript("EXAMPLE1234")
 
         assert transcript is not None
         assert len(transcript) == 2
         assert error is None
-        mock_yta_instance.list.assert_called_once_with("dQw4w9WgXcQ")
+        mock_yta_instance.list.assert_called_once_with("EXAMPLE1234")
 
     @patch("api.utils.youtube_transcript.YouTubeTranscriptApi")
     def test_no_transcript_found(self, mock_yta):
@@ -126,18 +126,18 @@ class TestFetchYouTubeTranscript:
         mock_yta.return_value = mock_yta_instance
         mock_list = MagicMock()
         mock_list.find_transcript.side_effect = NoTranscriptFound(
-            "dQw4w9WgXcQ",
+            "EXAMPLE1234",
             ["en", "es"],
             mock_list,
         )
         mock_list.find_generated_transcript.side_effect = NoTranscriptFound(
-            "dQw4w9WgXcQ",
+            "EXAMPLE1234",
             ["en", "es"],
             mock_list,
         )
         mock_yta_instance.list.return_value = mock_list
 
-        transcript, error = fetch_youtube_transcript("dQw4w9WgXcQ")
+        transcript, error = fetch_youtube_transcript("EXAMPLE1234")
 
         assert transcript is None
         assert error == "no transcript found"
@@ -167,7 +167,7 @@ class TestGetYouTubeTranscriptContext:
             None,
         )
 
-        result = get_youtube_transcript_context("dQw4w9WgXcQ")
+        result = get_youtube_transcript_context("EXAMPLE1234")
 
         assert "TRANSCRIPCION DEL VIDEO:" in result
         assert "[00:00] Hello world" in result
@@ -177,7 +177,7 @@ class TestGetYouTubeTranscriptContext:
     def test_returns_empty_on_error(self, mock_fetch):
         mock_fetch.return_value = (None, "no transcript found")
 
-        result = get_youtube_transcript_context("dQw4w9WgXcQ")
+        result = get_youtube_transcript_context("EXAMPLE1234")
 
         assert result == ""
 
@@ -185,6 +185,6 @@ class TestGetYouTubeTranscriptContext:
     def test_returns_empty_on_empty_transcript(self, mock_fetch):
         mock_fetch.return_value = ([], None)
 
-        result = get_youtube_transcript_context("dQw4w9WgXcQ")
+        result = get_youtube_transcript_context("EXAMPLE1234")
 
         assert result == ""


### PR DESCRIPTION
## Summary

- Replace real-world test fixture values with synthetic examples.
- Remove identifying names, handles, account IDs, post IDs, and video IDs.
- Preserve the existing behavioral coverage and platform-specific URL cases.

## Why

Test fixtures must not contain identifiers copied from live messages or public content.

## Impact

This changes test data only. Runtime behavior does not change.

## Validation

- `pytest -q` — 900 passed
- `ruff check` on all changed files — passed
- `git diff --check` — passed

The repository's locked `uv` checks cannot run locally because the installed `uv` version is 0.12.3, while the project requires a version from 0.11.21 through 0.11.x.
