### PR TITLE
Stop adding source lists to search answers

### DIFF
--- a/api/providers/openrouter.py
+++ b/api/providers/openrouter.py
@@ -224,29 +224,23 @@ class OpenRouterProvider(StreamingAIProvider):
                     )
                     continue
 
-                text_override = None
                 if total_web_search_requests > 0:
-                    text_override = self._runtime._finalize_web_search_answer(
+                    self._runtime._record_web_search_outcome(
                         streamed_round.text,
                         current_messages,
                         web_metadata,
                         tool_context=tool_context,
                         round_idx=round_idx,
                     )
-                if text_override is not None:
-                    web_metadata["stream_text_override"] = text_override
                 self._report_stream_usage(
                     on_usage_result,
                     usage_response,
                     message,
                     round_idx,
                     web_metadata,
-                    text_override=text_override,
                 )
 
-                if text_override is not None and not text_released:
-                    yield text_override
-                elif held_text:
+                if held_text:
                     yield held_text
 
                 if streamed_round.finish_reason in {"stop", "length", None}:

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -913,11 +913,12 @@ class ProviderRuntime:
             self._deps.increment_request_count()
             return ToolRoundDecision(updated_messages, continue_rounds=True)
 
+        text = str(getattr(message, "content", "") or "")
         web_metadata = self._web_search_metadata(response, message)
         if total_web_search_requests > 0:
             web_metadata["web_search_requests"] = total_web_search_requests
             self._record_web_search_outcome(
-                str(getattr(message, "content", "") or ""),
+                text,
                 current_messages,
                 web_metadata,
                 tool_context=tool_context,
@@ -926,11 +927,15 @@ class ProviderRuntime:
 
         return ToolRoundDecision(
             current_messages,
-            result=self._build_round_result(
-                response,
-                message,
-                round_idx,
-                metadata=web_metadata,
+            result=(
+                self._build_round_result(
+                    response,
+                    message,
+                    round_idx,
+                    metadata=web_metadata,
+                )
+                if text.strip()
+                else None
             ),
         )
 

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -25,10 +25,9 @@ from api.tools.runtime import ToolRuntime
 logger = get_logger(__name__)
 _MAX_RETRIES = 2
 _UNGROUNDED_SEARCH_MESSAGE = (
-    "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
-    "resultados citables; probá de nuevo en un momento."
+    "No pude verificar eso. La búsqueda web falló o no devolvió resultados útiles; "
+    "probá de nuevo en un momento."
 )
-_MAX_WEB_SEARCH_SOURCES = 3
 _MAX_LOGGED_SEARCH_ANSWER_CHARS = 4_000
 _PSEUDO_TOOL_CALL_PATTERN = re.compile(
     r'^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\((?P<arguments>.*)\)\s*$',
@@ -846,13 +845,8 @@ class ProviderRuntime:
         metadata["web_search_source_count"] = len(source_urls)
         clean_text = text.strip()
         if source_urls and clean_text:
-            selected_sources = source_urls[:_MAX_WEB_SEARCH_SOURCES]
-            missing_sources = [url for url in selected_sources if url not in text]
             metadata["web_search_grounded"] = True
-            metadata["web_search_citation_count"] = len(selected_sources)
-            if not missing_sources:
-                return None
-            return f"{text.rstrip()}\n\nfuentes: {' '.join(missing_sources)}"
+            return None
 
         if metadata.get("web_search_citation_count") and clean_text:
             metadata["web_search_grounded"] = True

--- a/api/providers/runtime.py
+++ b/api/providers/runtime.py
@@ -24,11 +24,6 @@ from api.tools.runtime import ToolRuntime
 
 logger = get_logger(__name__)
 _MAX_RETRIES = 2
-_UNGROUNDED_SEARCH_MESSAGE = (
-    "No pude verificar eso. La búsqueda web falló o no devolvió resultados útiles; "
-    "probá de nuevo en un momento."
-)
-_MAX_LOGGED_SEARCH_ANSWER_CHARS = 4_000
 _PSEUDO_TOOL_CALL_PATTERN = re.compile(
     r'^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\((?P<arguments>.*)\)\s*$',
     re.DOTALL,
@@ -832,7 +827,7 @@ class ProviderRuntime:
                     source_urls.append(source_url)
         return source_urls
 
-    def _finalize_web_search_answer(
+    def _record_web_search_outcome(
         self,
         text: str,
         current_messages: List[Dict[str, Any]],
@@ -840,17 +835,17 @@ class ProviderRuntime:
         *,
         tool_context: Optional[Dict[str, Any]],
         round_idx: int,
-    ) -> Optional[str]:
+    ) -> None:
         source_urls = self._web_search_source_urls(current_messages)
         metadata["web_search_source_count"] = len(source_urls)
         clean_text = text.strip()
         if source_urls and clean_text:
             metadata["web_search_grounded"] = True
-            return None
+            return
 
         if metadata.get("web_search_citation_count") and clean_text:
             metadata["web_search_grounded"] = True
-            return None
+            return
 
         metadata["web_search_grounded"] = False
         warning_context = dict(tool_context or {})
@@ -863,11 +858,9 @@ class ProviderRuntime:
             }
         )
         logger.warning(
-            "openrouter: rejecting web-search answer raw_answer=%r%s",
-            text[:_MAX_LOGGED_SEARCH_ANSWER_CHARS],
+            "openrouter: web-search answer has no supporting results%s",
             format_log_context(warning_context),
         )
-        return _UNGROUNDED_SEARCH_MESSAGE
 
     def _remaining_web_search_uses(
         self,
@@ -921,10 +914,9 @@ class ProviderRuntime:
             return ToolRoundDecision(updated_messages, continue_rounds=True)
 
         web_metadata = self._web_search_metadata(response, message)
-        text_override = None
         if total_web_search_requests > 0:
             web_metadata["web_search_requests"] = total_web_search_requests
-            text_override = self._finalize_web_search_answer(
+            self._record_web_search_outcome(
                 str(getattr(message, "content", "") or ""),
                 current_messages,
                 web_metadata,
@@ -939,7 +931,6 @@ class ProviderRuntime:
                 message,
                 round_idx,
                 metadata=web_metadata,
-                text_override=text_override,
             ),
         )
 

--- a/api/tools/web_search.py
+++ b/api/tools/web_search.py
@@ -148,7 +148,6 @@ def _parse_search_response(response: requests.Response, query: str) -> ToolResul
             {
                 "query": query,
                 "results": results,
-                "instruction": "Usá estas fuentes para responder y citá sus URLs.",
             },
             ensure_ascii=False,
         ),
@@ -186,7 +185,7 @@ register_tool(
     name="web_search",
     description=(
         "Search the public web with Firecrawl. Use it for current facts or when the user "
-        "asks you to search. The result contains source URLs that you must cite."
+        "asks you to search. The result contains source URLs and descriptions."
     ),
     parameters={
         "type": "object",

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -206,7 +206,7 @@ def test_provider_runtime_server_tool_use_takes_priority():
     assert result.metadata["web_search_requests"] == 3
 
 
-def test_provider_runtime_suppresses_web_search_answer_without_citations():
+def test_provider_runtime_suppresses_web_search_answer_without_results():
     response = _build_chat_response(
         text="seguro existe esa marca",
         usage={
@@ -227,7 +227,7 @@ def test_provider_runtime_suppresses_web_search_answer_without_citations():
         )
 
     assert result is not None
-    assert "No pude verificar eso con fuentes" in result.text
+    assert "No pude verificar eso" in result.text
     assert result.metadata["web_search_grounded"] is False
     assert result.metadata["web_search_citation_count"] == 0
     warning.assert_called_once()

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -206,7 +206,7 @@ def test_provider_runtime_server_tool_use_takes_priority():
     assert result.metadata["web_search_requests"] == 3
 
 
-def test_provider_runtime_suppresses_web_search_answer_without_results():
+def test_provider_runtime_keeps_web_search_answer_without_results():
     response = _build_chat_response(
         text="seguro existe esa marca",
         usage={
@@ -227,11 +227,10 @@ def test_provider_runtime_suppresses_web_search_answer_without_results():
         )
 
     assert result is not None
-    assert "No pude verificar eso" in result.text
+    assert result.text == "seguro existe esa marca"
     assert result.metadata["web_search_grounded"] is False
     assert result.metadata["web_search_citation_count"] == 0
     warning.assert_called_once()
-    assert warning.call_args.args[1] == "seguro existe esa marca"
 
 
 def test_provider_runtime_detects_pydantic_annotation():

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -1012,6 +1012,33 @@ def _build_retry_runtime(responses, *, extract_usage=lambda _response: {}):
     return runtime, client, admin_report, request_count
 
 
+def test_provider_runtime_returns_none_for_billable_empty_stop():
+    response = _FakeResponse(
+        [
+            _FakeChoice(
+                "stop",
+                SimpleNamespace(content="", tool_calls=[], annotations=[]),
+            )
+        ]
+    )
+    runtime, client, admin_report, request_count = _build_retry_runtime(
+        [response],
+        extract_usage=lambda _response: {"prompt_tokens": 10},
+    )
+
+    result = runtime.complete(
+        {"role": "system", "content": "sys"},
+        [{"role": "user", "content": "research this"}],
+        enable_web_search=True,
+        tool_context={"chat_id": "123"},
+    )
+
+    assert result is None
+    assert len(client.calls) == 1
+    assert request_count.call_count == 1
+    admin_report.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("retryable_finish_reason", "error"),
     [

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -66,7 +66,7 @@ def test_web_search_sources_ignore_urls_from_other_tools():
     assert ProviderRuntime._web_search_source_urls(messages) == []
 
 
-def test_provider_runtime_appends_sources_to_direct_search_answer():
+def test_provider_runtime_keeps_direct_search_answer_unchanged():
     from api.ai.pricing import AIUsageResult
     from api.providers.runtime import ProviderRuntime, ProviderRuntimeDeps
     from api.tools.runtime import ToolRuntime
@@ -154,12 +154,10 @@ def test_provider_runtime_appends_sources_to_direct_search_answer():
     )
 
     assert result is not None
-    assert result.text == (
-        "autor ejemplo es escritor y guionista\n\nfuentes: "
-        "https://example.com/profile https://example.com/interview"
-    )
+    assert result.text == "autor ejemplo es escritor y guionista"
     assert result.metadata["web_search_grounded"] is True
     assert result.metadata["web_search_source_count"] == 2
+    assert result.metadata["web_search_citation_count"] == 0
 
 
 def test_provider_runtime_executes_tool_calls_until_stop():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -392,10 +392,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
         (
             "Consulté https://example.com/not-a-result",
             '{"query":"https://example.com/not-a-result","results":[]}',
-            [
-                "No pude verificar eso. La búsqueda web falló o no devolvió resultados "
-                "útiles; probá de nuevo en un momento."
-            ],
+            ["Consulté https://example.com/not-a-result"],
             False,
             0,
         ),
@@ -421,10 +418,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
         (
             "",
             '{"results":[{"url":"https://example.com/profile"}]}',
-            [
-                "No pude verificar eso. La búsqueda web falló o no devolvió resultados "
-                "útiles; probá de nuevo en un momento."
-            ],
+            [],
             False,
             1,
         ),

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -385,10 +385,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             "La búsqueda falló y no encontré nada.",
             '{"results":[{"title":"Persona Ejemplo",'
             '"url":"https://example.com/profile"}]}',
-            [
-                "La búsqueda falló y no encontré nada.\n\n"
-                "fuentes: https://example.com/profile"
-            ],
+            ["La búsqueda falló y no encontré nada."],
             True,
             1,
         ),
@@ -396,8 +393,8 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             "Consulté https://example.com/not-a-result",
             '{"query":"https://example.com/not-a-result","results":[]}',
             [
-                "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
-                "resultados citables; probá de nuevo en un momento."
+                "No pude verificar eso. La búsqueda web falló o no devolvió resultados "
+                "útiles; probá de nuevo en un momento."
             ],
             False,
             0,
@@ -406,10 +403,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             "encontré su perfil en https://social.example/perfil/",
             '{"results":[{"title":"Persona Ejemplo",'
             '"url":"https://social.example/perfil/?lang=es"}]}',
-            [
-                "encontré su perfil en https://social.example/perfil/\n\n"
-                "fuentes: https://social.example/perfil/?lang=es"
-            ],
+            ["encontré su perfil en https://social.example/perfil/"],
             True,
             1,
         ),
@@ -420,10 +414,7 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             '{"url":"https://example.com/2"},'
             '{"url":"https://example.com/3"},'
             '{"url":"https://example.com/4"}]}',
-            [
-                "respuesta basada en los resultados\n\nfuentes: "
-                "https://example.com/1 https://example.com/2 https://example.com/3"
-            ],
+            ["respuesta basada en los resultados"],
             True,
             4,
         ),
@@ -431,15 +422,15 @@ def test_openrouter_stream_uses_web_search_branch_when_enabled():
             "",
             '{"results":[{"url":"https://example.com/profile"}]}',
             [
-                "No pude verificar eso con fuentes. La búsqueda web falló o no devolvió "
-                "resultados citables; probá de nuevo en un momento."
+                "No pude verificar eso. La búsqueda web falló o no devolvió resultados "
+                "útiles; probá de nuevo en un momento."
             ],
             False,
             1,
         ),
     ],
 )
-def test_openrouter_stream_executes_direct_web_search_and_validates_citations(
+def test_openrouter_stream_executes_direct_web_search_and_validates_results(
     final_text,
     search_output,
     expected_chunks,

--- a/tests/test_web_search.py
+++ b/tests/test_web_search.py
@@ -16,7 +16,7 @@ def _response(status_code, payload):
     return response
 
 
-def test_web_search_returns_compact_citable_results(monkeypatch):
+def test_web_search_returns_compact_results_without_response_instructions(monkeypatch):
     monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
     post = MagicMock(
         return_value=_response(
@@ -50,6 +50,7 @@ def test_web_search_returns_compact_citable_results(monkeypatch):
             "description": "Perfil público de Persona Ejemplo.",
         }
     ]
+    assert "instruction" not in payload
     assert "markdown" not in result.output
     assert result.metadata["result_count"] == 1
     assert post.call_args.kwargs["json"] == {


### PR DESCRIPTION
## Summary

- Stop instructing the model to print source URLs after web searches.
- Stop appending a second `fuentes:` block in the provider runtime.
- Remove the fixed search-failure response and return the model's answer unchanged.
- Keep search result availability in metadata and logs only.
- Let the provider chain continue when a provider returns an empty answer.

## Why

The search tool and provider runtime both added citation output. The runtime also replaced model responses when it could not find source URLs. These behaviors produced redundant source lists and discarded valid answers.

## Impact

The model receives Firecrawl results and errors directly, then responds in its configured style. Search metadata remains available for diagnostics, but it does not alter user-visible text. Empty provider responses use the normal fallback chain.

## Validation

- `pytest -q` — 901 passed
- `ruff check` on all changed files — passed
- `git diff --check` — passed
