### PR TITLE
Fix task scheduler startup wiring

### DIFF
--- a/run_polling.py
+++ b/run_polling.py
@@ -68,6 +68,7 @@ def main() -> int:
     setup_logging()
 
     from api import index
+    from api.bot.general_commands import gen_random
     from api.bot.ptb import run_polling
     from api.markets.world_cup_goals import (
         WorldCupGoalMonitor,
@@ -75,33 +76,36 @@ def main() -> int:
     )
     from api.tasks.scheduler import get_scheduler, init_scheduler
 
+    runtime = index.app_runtime
     threading.Thread(target=_price_refresh_loop, daemon=True).start()
-    index.app_runtime.summary.start_background_worker()
+    runtime.summary.start_background_worker()
     start_world_cup_goal_monitor(
         WorldCupGoalMonitor(
             list_chat_ids=index.list_world_cup_goal_chat_ids,
-            ask_ai=index.app_runtime.ai.ask,
-            send_message=index.app_runtime.telegram.send_message,
-            credits_db_service=index.credits_db_service,
-            estimate_ai_base_reserve_credits=index.estimate_ai_base_reserve_credits,
+            ask_ai=runtime.ai.ask,
+            send_message=runtime.telegram.send_message,
+            credits_db_service=runtime.billing.credits,
+            estimate_ai_base_reserve_credits=(
+                runtime.estimate_ai_base_reserve_credits
+            ),
             scoreboard=index._world_cup_scoreboard,
         )
     )
 
     try:
         init_scheduler(
-            redis_factory=index.config_redis,
+            redis_factory=runtime.config.redis,
             task_executor_deps={
-                "ask_ai": index.ask_ai,
-                "send_msg": index.send_msg,
-                "admin_report": index.admin_report,
-                "credits_db_service": index.credits_db_service,
-                "gen_random_fn": index.gen_random,
+                "ask_ai": runtime.ai.ask,
+                "send_msg": runtime.telegram.send_message,
+                "admin_report": runtime.admin.report,
+                "credits_db_service": runtime.billing.credits,
+                "gen_random_fn": gen_random,
                 "build_insufficient_credits_message_fn": (
-                    index.build_insufficient_credits_message
+                    runtime.billing.build_insufficient_message
                 ),
                 "estimate_ai_base_reserve_credits": (
-                    index.estimate_ai_base_reserve_credits
+                    runtime.estimate_ai_base_reserve_credits
                 ),
             },
         )

--- a/tests/test_bot_ptb.py
+++ b/tests/test_bot_ptb.py
@@ -200,7 +200,10 @@ class PollingEntrypointTests(unittest.TestCase):
                 clear=True,
             ),
             patch("run_polling._load_dotenv"),
+            patch("run_polling.threading.Thread"),
             patch("api.bot.ptb.run_polling") as mock_run_polling,
+            patch("api.tasks.scheduler.init_scheduler") as mock_init_scheduler,
+            patch("api.tasks.scheduler.get_scheduler") as mock_get_scheduler,
         ):
             import importlib
             import run_polling
@@ -212,6 +215,37 @@ class PollingEntrypointTests(unittest.TestCase):
             token="abc",
             drop_pending_updates=True,
             allowed_updates=["message", "callback_query", "pre_checkout_query"],
+        )
+        mock_get_scheduler.assert_called_once_with()
+
+        from api import index
+
+        scheduler_kwargs = mock_init_scheduler.call_args.kwargs
+        self.assertEqual(
+            scheduler_kwargs["redis_factory"],
+            index.app_runtime.config.redis,
+        )
+        task_deps = scheduler_kwargs["task_executor_deps"]
+        self.assertEqual(task_deps["ask_ai"], index.app_runtime.ai.ask)
+        self.assertEqual(
+            task_deps["send_msg"],
+            index.app_runtime.telegram.send_message,
+        )
+        self.assertEqual(task_deps["admin_report"], index.app_runtime.admin.report)
+        self.assertIs(
+            task_deps["credits_db_service"],
+            index.app_runtime.billing.credits,
+        )
+        from api.bot.general_commands import gen_random
+
+        self.assertEqual(task_deps["gen_random_fn"], gen_random)
+        self.assertEqual(
+            task_deps["build_insufficient_credits_message_fn"],
+            index.app_runtime.billing.build_insufficient_message,
+        )
+        self.assertEqual(
+            task_deps["estimate_ai_base_reserve_credits"],
+            index.app_runtime.estimate_ai_base_reserve_credits,
         )
 
     def test_main_requires_token(self):


### PR DESCRIPTION
## What changed

- Replaced stale `api.index` scheduler dependencies with services from `ApplicationRuntime`.
- Applied the same runtime wiring to the World Cup goal monitor.
- Added a polling-entrypoint regression test that verifies every scheduler dependency.
- Prevented the entrypoint test from starting background network threads.

## Root cause

`run_polling.py` still referenced module-level helpers removed during the `ApplicationRuntime` refactor. Scheduler initialization stopped at the first missing attribute, `api.index.config_redis`, and the catch-all startup handler reduced the failure to a warning. The scheduler never started, so persisted tasks could not run automatically.

## Impact

The task scheduler now receives Redis, AI, Telegram, administration, billing, and estimation services from the active application runtime. Startup tests fail if these dependencies become stale again.

## Validation

- `pytest -q` — 903 passed
- `pytest -q tests/test_bot_ptb.py tests/test_task_scheduler_fixes.py` — 48 passed
- `ruff check run_polling.py tests/test_bot_ptb.py`
- `mypy --follow-imports=skip run_polling.py`
- `git diff --check`
